### PR TITLE
Enable pinning of watched threads by default

### DIFF
--- a/src/General/Config.coffee
+++ b/src/General/Config.coffee
@@ -658,7 +658,7 @@ http://iqdb.org/?url=%TURL
     'Index Sort': 'bump'
     'Index Size': 'small'
     'Show Replies': true
-    'Pin Watched Threads': false
+    'Pin Watched Threads': true
     'Anchor Hidden Threads': true
     'Refreshed Navigation': false
 


### PR DESCRIPTION
Pin/anchor watched threads to the top of the catalog by default.