### PR TITLE
Fix Google search with certain images and browsers

### DIFF
--- a/src/General/Config.coffee
+++ b/src/General/Config.coffee
@@ -708,7 +708,7 @@ Config =
     MD5: ''
 
   sauces: """
-    https://www.google.com/searchbyimage?image_url=%IMG%3Fs.jpg
+    https://images.google.com/searchbyimage?image_url=%IMG%3Fs.jpg
     //iqdb.org/?url=%IMG
     http://eye.swfchan.com/search/?q=%name;types:swf;sandbox
     #//tineye.com/search?url=%IMG

--- a/src/General/Settings.coffee
+++ b/src/General/Settings.coffee
@@ -342,6 +342,9 @@ Settings =
     if compareString < '00001.00011.00021.00003'
       unless data['Remember Your Posts']?
         changes['Remember Your Posts'] = data['Mark Quotes of You'] ? true
+    if compareString < '00001.00011.00021.00006'
+      if data['sauces']?
+        changes['sauces'] = (changes['sauces'] ? data['sauces']).replace /^(#?\s*https:\/\/)www(\.google\.com\/searchbyimage\?image_url=%(?:IMG|URL)%3Fs\.jpg)(?=$|;)/mg, '$1images$2'
     changes
 
   loadSettings: (data, cb) ->


### PR DESCRIPTION
For some reason reverse image search on Google doesn't work sometimes on recent versions of Firefox. I don't know exactly what causes the issue (sometimes getting "URL not public" error, other times "image too large") and the problem could very well be something else but this seemed to fix it for me.

Maybe people that were still having issues could confirm if this fixes it for them too?

Related to #670.