### PR TITLE
Add b-stats archive

### DIFF
--- a/src/Archive/archives.json
+++ b/src/Archive/archives.json
@@ -80,4 +80,14 @@
   "boards": ["c", "d", "e", "i", "lgbt", "t", "u"],
   "files": ["c", "d", "e", "i", "lgbt", "t", "u"],
   "search": []
+}, {
+  "uid": 26,
+  "name": "bstats",
+  "domain": "archive.b-stats.org",
+  "http": true,
+  "https": true,
+  "software": "foolfuuka",
+  "boards": ["f", "cm", "hm", "lgbt", "news", "trash", "y"],
+  "files": [],
+  "search": []
 }]


### PR DESCRIPTION
Technically, it's not foolfuuka but I've made the URLs and API work. If things get too crazy I'll probably remove the fuuka adapter. Some boards have been archiving longer than many existing archives.