### PR TITLE
After hiding a thread, scroll to the collapsed thread.

### DIFF
--- a/src/Filtering/ThreadHiding.coffee
+++ b/src/Filtering/ThreadHiding.coffee
@@ -178,6 +178,8 @@ ThreadHiding =
     thread.isHidden = true
     Index.updateHideLabel() if Conf['JSON Index']
 
+    Header.scrollTo threadRoot
+
     return threadRoot.hidden = true unless makeStub
 
     ThreadHiding.makeStub thread, threadRoot


### PR DESCRIPTION
Add a single line to ThreadHiding.hide


The reason for this is say you are halfway through a 200-reply post then you press the hotkey 'x' to hide the post. Then you are scrolled all the way to the bottom of the page, but it is unlikely that is where you want to be. Thus, my change makes you jump back to the newly collapsed thread so you can instantly continue on to reading the next thread.