### PR TITLE
Add keybind, default state option to toggleable watcher

### DIFF
--- a/src/Miscellaneous/Keybinds.coffee
+++ b/src/Miscellaneous/Keybinds.coffee
@@ -97,6 +97,9 @@ Keybinds =
       when Conf['Update thread watcher']
         return unless ThreadWatcher.enabled
         ThreadWatcher.buttonFetchAll()
+      when Conf['Toggle thread watcher']
+        return unless ThreadWatcher.enabled and Conf['Toggleable Thread Watcher']
+        ThreadWatcher.toggleWatcher()
       # Images
       when Conf['Expand image']
         return unless ImageExpand.enabled and threadRoot

--- a/src/Miscellaneous/Keybinds.coffee
+++ b/src/Miscellaneous/Keybinds.coffee
@@ -98,7 +98,7 @@ Keybinds =
         return unless ThreadWatcher.enabled
         ThreadWatcher.buttonFetchAll()
       when Conf['Toggle thread watcher']
-        return unless ThreadWatcher.enabled and Conf['Toggleable Thread Watcher']
+        return unless ThreadWatcher.enabled
         ThreadWatcher.toggleWatcher()
       # Images
       when Conf['Expand image']

--- a/src/Monitoring/ThreadWatcher.coffee
+++ b/src/Monitoring/ThreadWatcher.coffee
@@ -38,7 +38,6 @@ ThreadWatcher =
       @dialog.hidden = true
     
     Header.addShortcut 'watcher', sc, 510
-    $.addClass doc, 'toggleable-watcher'
 
     ThreadWatcher.fetchAuto()
 

--- a/src/Monitoring/ThreadWatcher.coffee
+++ b/src/Monitoring/ThreadWatcher.coffee
@@ -34,11 +34,11 @@ ThreadWatcher =
 
     if Conf['Fixed Thread Watcher']
       $.addClass doc, 'fixed-watcher'
-    if Conf['Toggleable Thread Watcher']
-      if !Conf['Watcher Defaults to Visible']
-        @dialog.hidden = true
-      Header.addShortcut 'watcher', sc, 510
-      $.addClass doc, 'toggleable-watcher'
+    if !Conf['Persistent Thread Watcher']
+      @dialog.hidden = true
+    
+    Header.addShortcut 'watcher', sc, 510
+    $.addClass doc, 'toggleable-watcher'
 
     ThreadWatcher.fetchAuto()
 

--- a/src/Monitoring/ThreadWatcher.coffee
+++ b/src/Monitoring/ThreadWatcher.coffee
@@ -35,7 +35,8 @@ ThreadWatcher =
     if Conf['Fixed Thread Watcher']
       $.addClass doc, 'fixed-watcher'
     if Conf['Toggleable Thread Watcher']
-      @dialog.hidden = true
+      if !Conf['Watcher Defaults to Visible']
+        @dialog.hidden = true
       Header.addShortcut 'watcher', sc, 510
       $.addClass doc, 'toggleable-watcher'
 

--- a/src/config/Config.coffee
+++ b/src/config/Config.coffee
@@ -389,6 +389,11 @@ Config =
         'Adds a shortcut for the thread watcher and hides the watcher by default.'
         1
       ]
+      'Watcher Defaults to Visible': [
+        false
+        'Displays the thread watcher by default, rather than hiding it.'
+        2
+      ]
       'Mark New IPs': [
         false
         'Label each post from a new IP with the thread\'s current IP count.'
@@ -856,6 +861,10 @@ Config =
     'Update thread watcher': [
       'Shift+r'
       'Manually refresh thread watcher.'
+    ]
+    'Toggle thread watcher': [
+      't'
+      'Toggle visibility of thread watcher when toggle is enabled'
     ]
     # Images
     'Expand image': [

--- a/src/config/Config.coffee
+++ b/src/config/Config.coffee
@@ -384,15 +384,10 @@ Config =
         'Makes the thread watcher scroll with the page.'
         1
       ]
-      'Toggleable Thread Watcher': [
+      'Persistent Thread Watcher': [
         true
-        'Adds a shortcut for the thread watcher and hides the watcher by default.'
+        'The thread watcher will be visible when the page is loaded.'
         1
-      ]
-      'Watcher Defaults to Visible': [
-        false
-        'Displays the thread watcher by default, rather than hiding it.'
-        2
       ]
       'Mark New IPs': [
         false
@@ -864,7 +859,7 @@ Config =
     ]
     'Toggle thread watcher': [
       't'
-      'Toggle visibility of thread watcher when toggle is enabled'
+      'Toggle visibility of thread watcher.'
     ]
     # Images
     'Expand image': [

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -931,9 +931,6 @@ span.hide-announcement {
 #thread-watcher a {
   text-decoration: none;
 }
-:root:not(.toggleable-watcher) #thread-watcher .move > .close {
-  display: none;
-}
 #thread-watcher .move > .close {
   position: absolute;
   right: 0px;


### PR DESCRIPTION
Addresses #956 by adding a keybind to toggle visibility of thread
watcher rather than simply the header bar icon. Also adds an option in
config for the watcher to default to visible or not.