### PR TITLE
Add keybinding for toggling custom cooldown

### DIFF
--- a/src/Miscellaneous/Keybinds.coffee
+++ b/src/Miscellaneous/Keybinds.coffee
@@ -196,6 +196,10 @@ Keybinds =
       when Conf['Next Post Quoting You']
         return unless threadRoot and QuoteYou.db
         QuoteYou.cb.seek 'following'
+      when Conf['Toggle Cooldown']
+        return unless Conf['customCooldown']
+        return unless QR.nodes
+        QR.toggleCustomCooldown()
       <% if (readJSON('/.tests_enabled')) { %>
       when 'v'
         return unless threadRoot

--- a/src/Posting/QR.coffee
+++ b/src/Posting/QR.coffee
@@ -203,7 +203,7 @@ QR =
     QR.nodes.customCooldown.classList.toggle 'disabled', !enabled
 
   toggleCustomCooldown: ->
-    enabled = $.hasClass @, 'disabled'
+    enabled = 'disabled' in QR.nodes.customCooldown.classList
     QR.setCustomCooldown enabled
     $.set 'customCooldownEnabled', enabled
 

--- a/src/config/Config.coffee
+++ b/src/config/Config.coffee
@@ -996,6 +996,10 @@ Config =
       'Alt+Down'
       'Scroll to the next post that quotes you.'
     ]
+    'Toggle Cooldown': [
+      'Shift+p'
+      'Toggle custom cooldown timer.'
+    ]
 
   updater:
     checkbox:

--- a/src/config/Config.coffee
+++ b/src/config/Config.coffee
@@ -997,7 +997,7 @@ Config =
       'Scroll to the next post that quotes you.'
     ]
     'Toggle Cooldown': [
-      'Shift+p'
+      'Alt+Comma'
       'Toggle custom cooldown timer.'
     ]
 


### PR DESCRIPTION
Adds the ability to set a keybind for toggling the custom cooldown in the QR (defaults to Alt+,).

`return unless QR.nodes` deals with it failing if QR hasn't already been enabled.