### PR TITLE
Add option to sort index by reverse bump order.

### DIFF
--- a/src/General/Index.coffee
+++ b/src/General/Index.coffee
@@ -342,12 +342,18 @@ Index =
       'all-pages':     'all pages'
       'catalog':       'catalog'
     sort:
-      'bump-order':    'bump'
-      'last-reply':    'lastreply'
-      'last-long-reply': 'lastlong'
-      'creation-date': 'birth'
-      'reply-count':   'replycount'
-      'file-count':    'filecount'
+      'bump-order':        'bump'
+      'bump-order-rev':    'bump-rev'
+      'last-reply':        'lastreply'
+      'last-reply-rev':    'lastreply-rev'
+      'last-long-reply':   'lastlong'
+      'last-long-reply-rev': 'lastlong-rev'
+      'creation-date':     'birth'
+      'creation-date-rev': 'birth-rev'
+      'reply-count':       'replycount'
+      'reply-count-rev':   'replycount-rev'
+      'file-count':        'filecount'
+      'file-count-rev':    'filecount-rev'
 
   processHash: ->
     # XXX https://bugzilla.mozilla.org/show_bug.cgi?id=483304

--- a/src/General/Index/NavLinks.html
+++ b/src/General/Index/NavLinks.html
@@ -6,6 +6,7 @@
 <input type="search" id="index-search" class="field" placeholder="Search">
 <a id="index-search-clear" href="javascript:;" title="Clear search">×</a>
 <span id="hidden-label" hidden> &mdash; <span id="hidden-count"></span> <span id="hidden-toggle">[<a href="javascript:;">Show</a>]</span></span>
+<input type="checkbox" id="index-rev" name="Reverse Sort" title="Check to reverse sort order">
 <select id="index-mode" name="Index Mode">
   <option disabled>Index Mode</option>
   <option value="paged">Paged</option>

--- a/src/General/Settings/Advanced.html
+++ b/src/General/Settings/Advanced.html
@@ -40,7 +40,7 @@
   <div>Index-only link: <code>g-index</code></div>
   <div>Catalog-only link: <code>g-catalog</code></div>
   <div>Index mode: <code>g-mode:&quot;infinite scrolling&quot;</code></div>
-  <div>Index sort: <code>g-sort:&quot;creation date&quot;</code></div>
+  <div>Index sort: <code>g-sort:&quot;creation date rev&quot;</code></div>
   <div>External link: <code>external-text:&quot;Google&quot;,&quot;http://www.google.com&quot;</code></div>
   <div>Combinations are possible: <code>g-index-text:&quot;Technology Index&quot;</code></div>
   <div>Full board list toggle: <code>toggle-all</code></div>

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -703,7 +703,7 @@ div[data-checked="false"] > .suboption-list {
 #index-search:not([data-searching]) + #index-search-clear {
   display: none;
 }
-#index-mode, #index-sort, #index-size {
+#index-rev, #index-mode, #index-sort, #index-size {
   float: right;
 }
 .summary {


### PR DESCRIPTION
Especially for faster boards,  interesting threads can already be archived by the time you reach them scanning down with other sorts. This commit brings those threads most at risk of being bumped off to the top. Versus having a keen user move to the end of their preferred index mode, this respects pinned threads and typical scrolling direction.

I considered generalizing this behavior to other sort orders, but I would rather have your thoughts regarding implementation details and whether you care to include this at all first. I was thinking of a checkbox with only hover text placed after the NavLinks dropdowns that sets a flag, keeping it accessible but unobtrusive.
