### PR TITLE
Added filename substring method to Sauce

### DIFF
--- a/src/General/Settings/Sauce.html
+++ b/src/General/Settings/Sauce.html
@@ -11,6 +11,7 @@
   <li><code>%sMD5</code>: MD5 hash in base64 using <code>-</code> and <code>_</code>.</li>
   <li><code>%hMD5</code>: MD5 hash in hexadecimal.</li>
   <li><code>%name</code>: Original file name.</li>
+  <li><code>%sname[start,len]</code>: A sub-string of the file name from position <code>start</code> of lenght <code>len</code>. Allows negative numbers on <code>start</code>. Also works as <code>%sname[len]</code></li>
   <li><code>%board</code>: Current board.</li>
   <li><code>%%</code>, <code>%semi</code>: Literal <code>%</code> and <code>;</code>.</li>
 </ul>

--- a/src/Images/Sauce.coffee
+++ b/src/Images/Sauce.coffee
@@ -33,8 +33,12 @@ Sauce =
 
     skip = false
     for key of parts
-      parts[key] = parts[key].replace /%(T?URL|IMG|[sh]?MD5|board|name|%|semi)/g, (_, parameter) ->
-        type = Sauce.formatters[parameter] post, ext
+      parts[key] = parts[key].replace /%(T?URL|IMG|[sh]?MD5|board|name|%|semi|sname\[-?\d*(\,-?\d*)?\])/g, (_, parameter) ->
+        if (parameter.substr(0,5)) is 'sname'
+            n1 = parseInt(parameter.match(/-?\d{1,}(?=\,)/g))
+            n2 = Math.abs(parseInt(parameter.match(/-?\d{1,}(?=\])/g)))
+            parameter = parameter.substr(0,5)
+        type = Sauce.formatters[parameter] post, ext, n1, n2
         if not type?
           skip = true
           return ''
@@ -85,3 +89,4 @@ Sauce =
     name:  (post) -> post.file.name
     '%':   -> '%'
     semi:  -> ';'
+    sname: (post, ext, a, b) -> post.file.name.match(/.+(?=\.\w)/g).toString().substr((0 or a),b)+'.'+ext;


### PR DESCRIPTION
Usage %sname[start,len] or %sname[len] - returns a substring of length
len from position start. Allows for start to have negative values,
wrapping around the end of the filename. extension and delimiting period
are excluded from the filename string but are re-appended at the end.
"0 or a" puzzles me.