### PR TITLE
Hide related videos when a youtube video is paused

### DIFF
--- a/src/Linkification/Embedding.coffee
+++ b/src/Linkification/Embedding.coffee
@@ -442,7 +442,7 @@ Embedding =
           start += ' 0h0m0s'
           start = 3600 * start.match(/(\d+)h/)[1] + 60 * start.match(/(\d+)m/)[1] + 1 * start.match(/(\d+)s/)[1]
         el = $.el 'iframe',
-          src: "//www.youtube.com/embed/#{a.dataset.uid}?wmode=opaque#{if start then '&start=' + start else ''}"
+          src: "//www.youtube.com/embed/#{a.dataset.uid}?rel=0&wmode=opaque#{if start then '&start=' + start else ''}"
         el.setAttribute "allowfullscreen", "true"
         el
       title:


### PR DESCRIPTION
This is what it looks like with the current 4chan-x version whenever the video is paused:

![2017-05-06-165917_655x391_scrot](https://cloud.githubusercontent.com/assets/1882250/25773430/7e64c08c-327d-11e7-873b-2bb074ba4f5f.png)

And with the patch the band at the bottom is not shown. The band is a major annoyance if you're used to maximizing videos by double clicking.