### PR TITLE
Fix 'open thread in new tab' keybind for VM/TM

### DIFF
--- a/src/Miscellaneous/Keybinds.coffee
+++ b/src/Miscellaneous/Keybinds.coffee
@@ -312,7 +312,7 @@ Keybinds =
     return if g.VIEW isnt 'index'
     url = "/#{thread.board}/thread/#{thread}"
     if tab
-      $.open url
+      $.open location.origin + url
     else
       location.href = url
 


### PR DESCRIPTION
Fixes 'open thread in new tab' keybind functionality when using violentmonkey/tampermonkey