### PR TITLE
'Overloading' of thread & reply navigation hotkey bindings.

### DIFF
--- a/src/Miscellaneous/Keybinds.coffee
+++ b/src/Miscellaneous/Keybinds.coffee
@@ -190,7 +190,7 @@ Keybinds =
               Keybinds.open thread, true
             else
               return
-        if threadRoot
+        else if threadRoot
           switch key
             # Reply Navigation
             when Conf['Next reply']

--- a/src/Miscellaneous/Keybinds.coffee
+++ b/src/Miscellaneous/Keybinds.coffee
@@ -169,54 +169,52 @@ Keybinds =
       when Conf['Cycle sort type']
         return unless Conf['JSON Index'] and g.VIEW is 'index' and g.BOARD.ID isnt 'f'
         Index.cycleSortType()
-      # Thread Navigation
-      when Conf['Next thread']
-        return unless g.VIEW is 'index' and threadRoot
-        Nav.scroll +1
-      when Conf['Previous thread']
-        return unless g.VIEW is 'index' and threadRoot
-        Nav.scroll -1
-      when Conf['Expand thread']
-        return unless g.VIEW is 'index' and threadRoot
-        ExpandThread.toggle thread
-      when Conf['Open thread']
-        return unless g.VIEW is 'index' and threadRoot
-        Keybinds.open thread
-      when Conf['Open thread tab']
-        return unless g.VIEW is 'index' and threadRoot
-        Keybinds.open thread, true
-      # Reply Navigation
-      when Conf['Next reply']
-        return unless threadRoot
-        Keybinds.hl +1, threadRoot
-      when Conf['Previous reply']
-        return unless threadRoot
-        Keybinds.hl -1, threadRoot
-      when Conf['Deselect reply']
-        return unless threadRoot
-        Keybinds.hl  0, threadRoot
-      when Conf['Hide']
-        return unless thread and ThreadHiding.db
-        Header.scrollTo threadRoot
-        ThreadHiding.toggle thread
-      when Conf['Quick Filter MD5']
-        return unless threadRoot
-        post = Keybinds.post threadRoot
-        Keybinds.hl +1, threadRoot
-        Filter.quickFilterMD5.call post
-      when Conf['Previous Post Quoting You']
-        return unless threadRoot and QuoteYou.db
-        QuoteYou.cb.seek 'preceding'
-      when Conf['Next Post Quoting You']
-        return unless threadRoot and QuoteYou.db
-        QuoteYou.cb.seek 'following'
       <% if (readJSON('/.tests_enabled')) { %>
       when 'v'
         return unless threadRoot
         Build.Test.testAll()
       <% } %>
       else
-        return
+        if g.VIEW is 'index' and threadRoot
+          switch key
+            # Thread Navigation
+            when Conf['Next thread']
+              Nav.scroll +1
+            when Conf['Previous thread']
+              Nav.scroll -1
+            when Conf['Expand thread']
+              ExpandThread.toggle thread
+            when Conf['Open thread']
+              Keybinds.open thread
+            when Conf['Open thread tab']
+              Keybinds.open thread, true
+            else
+              return
+        if threadRoot
+          switch key
+            # Reply Navigation
+            when Conf['Next reply']
+              Keybinds.hl +1, threadRoot
+            when Conf['Previous reply']
+              Keybinds.hl -1, threadRoot
+            when Conf['Deselect reply']
+              Keybinds.hl  0, threadRoot
+            when Conf['Hide']
+              return unless ThreadHiding.db
+              Header.scrollTo threadRoot
+              ThreadHiding.toggle thread
+            when Conf['Quick Filter MD5']
+              post = Keybinds.post threadRoot
+              Keybinds.hl +1, threadRoot
+              Filter.quickFilterMD5.call post
+            when Conf['Previous Post Quoting You']
+              return unless QuoteYou.db
+              QuoteYou.cb.seek 'preceding'
+            when Conf['Next Post Quoting You']
+              return unless QuoteYou.db
+              QuoteYou.cb.seek 'following'
+            else
+              return
     e.preventDefault()
     e.stopPropagation()
 


### PR DESCRIPTION
# Overview
Branch `hotkey-tweak` modifies handling of thread and reply navigational hotkeys to allow 'overloaded' bindings in different contexts (viewing index vs viewing thread). This allows the user to share the same hotkeys for navigating between threads and navigating between replies, depending on the view.

# Reasoning
Using the current 4chan-x released userscript, I set the hotkeys for "Next Thread" and "Next Reply" to `Ctrl+Down`; I also set the hotkeys for "Previous Thread" and "Previous Reply" to `Ctrl+Up`.

With these duplicate entries, I would expect the following behaviour:
* On a board index, pressing `Ctrl+Down` would navigate down a thread, and pressing `Ctrl+Up` would navigate up a thread
* Within a thread, pressing `Ctrl+Down` would navigate down a reply, and pressing `Ctrl+Up` would navigate up a reply

While the first test functions as expected, the second fails. Pressing the 'overloaded' "Next Reply" hotkey while in a thread view scrolls to the bottom of the entire thread. Pressing the overloaded "Previous Reply" hotkey scrolls the view to the top of the thread. No posts are highlighted.

Upon investigating `Keybinds.coffee`, I discovered that this was due to the thread navigation hotkeys appearing before the reply navigation hotkeys in the keydown event's switch, preventing the reply navigation hotkey's effect from occurring as expected.

# Modification
Thread and reply navigation hotkey detection was moved into conditional blocks, detecting the current view context before filtering for appropriate hotkeys. My initial attempt involved creating a new configuration option to allow hotkeys to 'fall though' if the precondition for the hotkey (eg, `g.VIEW is 'index' and threadRoot`) is not matched.

I viewed the simplest manner to implement such a change in the `Keybinds.coffee` file would be to allow falling through the switch cases instead of returning if the precondition is not matched, but I have not used Coffeescript much before, and was not familiar with the project's curious decision [on](https://github.com/jashkenas/coffeescript/issues/1891) [the](https://github.com/jashkenas/coffeescript/issues/2343) [matter](https://github.com/jashkenas/coffeescript/issues/2112) of allowing 'fallthrough' in their switches, so I applied a less generalized fix, specific to this issue of thread vs index navigation hotkeys.

Upon restructuring the section, I further removed the now-redundant conditional checks within the 'when'/case segments, as appropriate.

# Tests
Upon building my modifications and loading them into my browser (Firefox Nightly 59.0a1 [2017-11-14], Greasemonkey 4.0 [2017-11-15]), replacing the ordinary 4chan-x released userscript, thread and reply navigation now acts as I had originally anticipated. I did not observe any unintended side-effects of my change other than allowing overloading of hotkeys between thread and reply navigation, but I encourage further testing to ensure.