### PR TITLE
[#1581] Prevents filtering of own posts with filters

### DIFF
--- a/src/Filtering/Filter.coffee
+++ b/src/Filtering/Filter.coffee
@@ -125,7 +125,7 @@ Filter =
     stub = true
     hl   = undefined
     top  = false
-    if !Conf['Filter Self'] and QuoteYou.isYou(post)
+    if QuoteYou.isYou(post)
       hideable = false
     for key of Filter.filters when ((value = Filter[key] post)?)
       # Continue if there's nothing to filter (no tripcode for example).

--- a/src/Filtering/Filter.coffee
+++ b/src/Filtering/Filter.coffee
@@ -125,6 +125,8 @@ Filter =
     stub = true
     hl   = undefined
     top  = false
+    if !Conf['Filter Self'] and QuoteYou.isYou(post)
+      hideable = false
     for key of Filter.filters when ((value = Filter[key] post)?)
       # Continue if there's nothing to filter (no tripcode for example).
       for filter in Filter.filters[key] when (result = filter value, post.boardID, post.isReply)

--- a/src/Quotelinks/QuoteYou.coffee
+++ b/src/Quotelinks/QuoteYou.coffee
@@ -33,8 +33,8 @@ QuoteYou =
 
   isYou: (post) ->
     !!QuoteYou.db?.get {
-      boardID:  post.board.ID
-      threadID: post.thread.ID
+      boardID:  post.boardID
+      threadID: post.threadID
       postID:   post.ID
     }
 

--- a/src/config/Config.coffee
+++ b/src/config/Config.coffee
@@ -179,11 +179,6 @@ Config =
         'When enabled, shows backlinks to filtered posts with a line-through decoration. Otherwise, hides the backlinks.'
         1
       ]
-      'Filter Self': [
-        true
-        'Also apply filters to posts known to be yours. (Remember Your Posts must be enabled)'
-        1
-      ]
       'Recursive Hiding': [
         true
         'Hide replies of hidden posts, recursively.'

--- a/src/config/Config.coffee
+++ b/src/config/Config.coffee
@@ -179,6 +179,11 @@ Config =
         'When enabled, shows backlinks to filtered posts with a line-through decoration. Otherwise, hides the backlinks.'
         1
       ]
+      'Filter Self': [
+        true
+        'Also apply filters to posts known to be yours. (Remember Your Posts must be enabled)'
+        1
+      ]
       'Recursive Hiding': [
         true
         'Hide replies of hidden posts, recursively.'


### PR DESCRIPTION
Implements requested functionality from issue #1581 

# Changes
Adds option 'Filter Self' under Filter section in configuration screen to control filtering posts known to be the user. Default value of 'true' was selected to retain existing behaviour for users uninterested in the change, but it may be desirable to adjust this default to be more intuitive.

Disabling 'Filter Self' will prevent filtering of user's own posts despite filter settings.

# Tested
Intended functionality confirmed in Firefox 59.0a1 (2017-11-14), using Greasemonkey 4.0 (2017-11-15). No apparent side-effects were observed, other than the intended change.