### PR TITLE
Customization of filename for pasted images in Quick Reply dialog

### DIFF
--- a/src/General/Settings.coffee
+++ b/src/General/Settings.coffee
@@ -506,7 +506,7 @@ Settings =
       $.id('lastarchivecheck').textContent = 'never'
 
     items = {}
-    for name in ['archiveLists', 'archiveAutoUpdate', 'captchaLanguage', 'boardnav', 'time', 'timeLocale', 'backlink', 'fileInfo', 'QR.personas', 'favicon', 'usercss', 'customCooldown', 'jsWhitelist']
+    for name in ['archiveLists', 'archiveAutoUpdate', 'captchaLanguage', 'boardnav', 'time', 'timeLocale', 'backlink', 'pastedname', 'fileInfo', 'QR.personas', 'favicon', 'usercss', 'customCooldown', 'jsWhitelist']
       items[name] = Conf[name]
       input = inputs[name]
       event = if name in ['archiveLists', 'archiveAutoUpdate', 'QR.personas', 'favicon', 'usercss'] then 'change' else 'input'
@@ -664,6 +664,9 @@ Settings =
 
   backlink: ->
     @nextElementSibling.textContent = @value.replace /%(?:id|%)/g, (x) -> ({'%id': '123456789', '%%': '%'})[x]
+
+  pastedname: -> 
+    @nextElementSibling.textContent = "#{@value}.png"
 
   fileInfo: ->
     data =

--- a/src/General/Settings.coffee
+++ b/src/General/Settings.coffee
@@ -666,7 +666,7 @@ Settings =
     @nextElementSibling.textContent = @value.replace /%(?:id|%)/g, (x) -> ({'%id': '123456789', '%%': '%'})[x]
 
   pastedname: -> 
-    @nextElementSibling.textContent = "#{@value}.png"
+    @nextElementSibling.textContent = @value.replace /%(?:ext|%)/g, (x) -> ({'%ext': 'png', '%%': '%'})[x]
 
   fileInfo: ->
     data =

--- a/src/General/Settings/Advanced.html
+++ b/src/General/Settings/Advanced.html
@@ -73,6 +73,11 @@
 </fieldset>
 
 <fieldset>
+  <legend>Default pasted content filename</legend>
+  <div><input name="pastedname" class="field" spellcheck="false">: <span class="pastedname-preview"></span></div>
+</fieldset>
+
+<fieldset>
   <legend>File Info Formatting <span class="warning" data-feature="File Info Formatting">is disabled.</span></legend>
   <div><input name="fileInfo" class="field" spellcheck="false">: <span class="file-info file-info-preview"></span></div>
   <div>Link: <code>%l</code> (truncated), <code>%L</code> (untruncated), <code>%T</code> (4chan filename)</div>

--- a/src/Posting/QR.coffee
+++ b/src/Posting/QR.coffee
@@ -395,8 +395,8 @@ QR =
     if file
       {type} = file
       blob = new Blob [file], {type}
-      pastedname = Conf['pastedname']
-      blob.name = "#{pastedname}.#{QR.extensionFromType[type] or 'jpg'}"
+      @ext = QR.extensionFromType[type] or 'jpg'
+      blob.name = Conf['pastedname'].replace(/%(?:ext|%)/g, (x) => ({'%ext': @ext, '%%': '%'})[x])
       QR.open()
       QR.handleFiles [blob]
       $.addClass QR.nodes.el, 'dump'
@@ -415,8 +415,8 @@ QR =
         for i in [0...bstr.length]
           arr[i] = bstr.charCodeAt(i)
         blob = new Blob [arr], {type: m[1]}
-        pastedname = Conf['pastedname']
-        blob.name = "#{pastedname}.#{m[2]}"
+        @ext = m[2]
+        blob.name = Conf['pastedname'].replace(/%(?:ext|%)/g, (x) => ({'%ext': @ext, '%%': '%'})[x])
         QR.handleFiles [blob]
       else if /^https?:\/\//.test src
         QR.handleUrl src

--- a/src/Posting/QR.coffee
+++ b/src/Posting/QR.coffee
@@ -395,7 +395,8 @@ QR =
     if file
       {type} = file
       blob = new Blob [file], {type}
-      blob.name = "file.#{QR.extensionFromType[type] or 'jpg'}"
+      pastedname = Conf['pastedname']
+      blob.name = "#{pastedname}.#{QR.extensionFromType[type] or 'jpg'}"
       QR.open()
       QR.handleFiles [blob]
       $.addClass QR.nodes.el, 'dump'
@@ -414,7 +415,8 @@ QR =
         for i in [0...bstr.length]
           arr[i] = bstr.charCodeAt(i)
         blob = new Blob [arr], {type: m[1]}
-        blob.name = "file.#{m[2]}"
+        pastedname = Conf['pastedname']
+        blob.name = "#{pastedname}.#{m[2]}"
         QR.handleFiles [blob]
       else if /^https?:\/\//.test src
         QR.handleUrl src

--- a/src/config/Config.coffee
+++ b/src/config/Config.coffee
@@ -866,7 +866,7 @@ Config =
 
   backlink: '>>%id'
 
-  pastedname: 'file'
+  pastedname: 'file.%ext'
 
   fileInfo: '%l %d (%p%s, %r%g)'
 

--- a/src/config/Config.coffee
+++ b/src/config/Config.coffee
@@ -866,6 +866,8 @@ Config =
 
   backlink: '>>%id'
 
+  pastedname: 'file'
+
   fileInfo: '%l %d (%p%s, %r%g)'
 
   favicon: 'ferongr'


### PR DESCRIPTION
Adds functionality requested in issue #1505 

# Changes
Essentially duplicated functionality used for custom backlinks to provide the user with a field to adjust the default naming of images added via pasting into the Quick Reply dialog. The %ext token is replaced with the file's extension, determined using existing logic.

Configuration value defaults to 'file.%ext' to remain consistent with existing behaviour.

# Tested
Intended functionality confirmed in Firefox 59.0a1 (2017-11-14), using Greasemonkey 4.0 (2017-11-15). No apparent side-effects were observed, other than the intended change.