### PR TITLE
Support Vocaroo HTTPS embedding

### DIFF
--- a/src/Linkification/Embedding.coffee
+++ b/src/Linkification/Embedding.coffee
@@ -455,7 +455,7 @@ Embedding =
           controls: true
           preload: 'auto'
         type = if el.canPlayType 'audio/webm' then 'webm' else 'mp3'
-        el.src = "http://vocaroo.com/media_command.php?media=#{a.dataset.uid}&command=download_#{type}"
+        el.src = "//vocaroo.com/media_command.php?media=#{a.dataset.uid}&command=download_#{type}"
         el
     ,
       key: 'YouTube'


### PR DESCRIPTION
Previously HTTP was forced, causing an unnecessary Mixed Content warning.