### PR TITLE
Enable more general Twitter image embedding

### DIFF
--- a/src/Linkification/Embedding.coffee
+++ b/src/Linkification/Embedding.coffee
@@ -420,6 +420,12 @@ Embedding =
         else
           el
     ,
+      key: 'TwitterImage'
+      regExp: /^\w+:\/\/pbs\.twimg\.com\/media\/([\w-]{15}\.(?:gif|png|jpg):\w+)/i
+      style: ''
+      el: (a) ->
+        $.el 'div', <%= html('<a target="_blank" href="https://pbs.twimg.com/media/${a.dataset.uid}"><img src="https://pbs.twimg.com/media/${a.dataset.uid}" style="max-width: 80vw; max-height: 80vh;"></a>') %>
+    ,
       key: 'VidLii'
       regExp:  /^\w+:\/\/(?:www\.)?vidlii\.com\/watch\?v=(\w{11})/
       style: 'border: none; width: 640px; height: 392px;'

--- a/src/Linkification/Embedding.coffee
+++ b/src/Linkification/Embedding.coffee
@@ -215,7 +215,7 @@ Embedding =
           src:         a.dataset.href
     ,
       key: 'image'
-      regExp: /^[^?#]+\.(?:gif|png|jpg|jpeg|bmp)(?:[?#]|$)/i
+      regExp: /^[^?#]+\.(?:gif|png|jpg|jpeg|bmp)(?::\w+)?(?:[?#]|$)/i
       style: ''
       el: (a) ->
         $.el 'div', <%= html('<a target="_blank" href="${a.dataset.href}"><img src="${a.dataset.href}" style="max-width: 80vw; max-height: 80vh;"></a>') %>
@@ -419,12 +419,6 @@ Embedding =
           cont
         else
           el
-    ,
-      key: 'TwitterImage'
-      regExp: /^\w+:\/\/pbs\.twimg\.com\/media\/([\w-]{15}\.(?:gif|png|jpg):\w+)/i
-      style: ''
-      el: (a) ->
-        $.el 'div', <%= html('<a target="_blank" href="https://pbs.twimg.com/media/${a.dataset.uid}"><img src="https://pbs.twimg.com/media/${a.dataset.uid}" style="max-width: 80vw; max-height: 80vh;"></a>') %>
     ,
       key: 'VidLii'
       regExp:  /^\w+:\/\/(?:www\.)?vidlii\.com\/watch\?v=(\w{11})/


### PR DESCRIPTION
You can get Twitter images in different sizes by appending a size (`:thumb`, `:large`, `:orig`, etc.) to the URL. Those weren't embeddable yet, because they no longer look like ordinary image URLs. This makes them embeddable.

I added it as a new embed type that embeds the same way as the `image` type, I hope that's appropriate.

I post a lot of Twitter links so this would be helpful.