### PR TITLE
Small textarea change in Settings

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -702,6 +702,7 @@ div[data-checked="false"] > .suboption-list {
   font-family: monospace;
   min-width: 100%;
   max-width: 100%;
+  resize: vertical;
 }
 #fourchanx-settings code {
   color: #000;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -700,8 +700,7 @@ div[data-checked="false"] > .suboption-list {
 }
 #fourchanx-settings textarea {
   font-family: monospace;
-  min-width: 100%;
-  max-width: 100%;
+  width: 100%;
   resize: vertical;
 }
 #fourchanx-settings code {


### PR DESCRIPTION
This ensures that the textareas in the Settings can only be resized vertically, so that they don't break out of the container.

If you went to resize it horizontally, it would actually close the settings dialog anyway.