### PR TITLE
Allow for links to open in new tab.

### DIFF
--- a/src/General/Header.coffee
+++ b/src/General/Header.coffee
@@ -191,7 +191,7 @@ Header =
     $.rmAll list
     return unless boardnav
     boardnav = boardnav.replace /(\r\n|\n|\r)/g, ' '
-    re = /[\w@]+(-(all|title|replace|full|index|catalog|archive|expired|(mode|sort|text):"[^"]+"(,"[^"]+")?))*|[^\w@]+/g
+    re = /[\w@]+(-(all|title|replace|full|index|catalog|archive|expired|nt|(mode|sort|text):"[^"]+"(,"[^"]+")?))*|[^\w@]+/g
     nodes = (Header.mapCustomNavigation(t) for t in boardnav.match re)
     $.add list, nodes
     CatalogLinks.setLinks list
@@ -293,6 +293,11 @@ Header =
         a.href = "//#{BoardConfig.domain(boardID)}/#{boardID}/archive"
       else
         return a.firstChild # Its text node.
+    
+    if /-nt/.test t
+      a.target = '_blank'
+      a.rel = 'noopener noreferrer';
+      return a
 
     $.addClass a, 'navSmall' if boardID is '@'
     a

--- a/src/General/Settings/Advanced.html
+++ b/src/General/Settings/Advanced.html
@@ -73,6 +73,7 @@
   <div>Index mode: <code>g-mode:&quot;infinite scrolling&quot;</code></div>
   <div>Index sort: <code>g-sort:&quot;creation date rev&quot;</code></div>
   <div>External link: <code>external-text:&quot;Google&quot;,&quot;http://www.google.com&quot;</code></div>
+  <div>Open in new tab: <code>g-nt</code></div>
   <div>Combinations are possible: <code>g-index-text:&quot;Technology Index&quot;</code></div>
   <div>Full board list toggle: <code>toggle-all</code></div>
   <br>


### PR DESCRIPTION
This *should* allow for `-nt` to be added, which will open in a new tab, or however the user has set `_blank` links to open.

Closes #504.