### PR TITLE
Update dump list CSS

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1023,6 +1023,7 @@ div[data-checked="false"] > .suboption-list {
 }
 .catalog-post .prettyprinted {
   max-width: 100%;
+  -moz-box-sizing: border-box;
   box-sizing: border-box;
 }
 .catalog-post .MathJax_Display {
@@ -1711,6 +1712,7 @@ input.field.tripped:not(:hover):not(:focus) {
 }
 .field {
   -moz-box-sizing: border-box;
+  box-sizing: border-box;
   margin: 0px;
   padding: 2px 4px 3px;
 }
@@ -1970,6 +1972,7 @@ input[type="checkbox"]:checked ~ .checkbox-letter {
 }
 .qr-preview {
   -moz-box-sizing: border-box;
+  box-sizing: border-box;
   counter-increment: thumbnails;
   cursor: move;
   display: inline-block;
@@ -2050,7 +2053,9 @@ a:only-of-type > .remove {
   position: absolute;
   bottom: 20px;
   right: 10px;
+  -webkit-transform: translateY(-50%);
   -moz-transform: translateY(-50%);
+  transform: translateY(-50%);
 }
 .textarea {
   position: relative;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -2054,7 +2054,6 @@ a:only-of-type > .remove {
   bottom: 20px;
   right: 10px;
   -webkit-transform: translateY(-50%);
-  -moz-transform: translateY(-50%);
   transform: translateY(-50%);
 }
 .textarea {


### PR DESCRIPTION
 - Adds both prefixed and unprefixed versions of `box-sizing` to some elements for consistency
 - Consistently `transform` the `#add-post` button across browsers

![image](https://user-images.githubusercontent.com/877480/79636883-6bc40800-81be-11ea-9808-fbad9428d846.png)

Left is Chromium, right is Gecko. Changing the CSS makes both look the same. When browser versions are bumped up, of course, no prefixes will be needed.