### PR TITLE
Fixed /vg/ problem of empty last_replies field

### DIFF
--- a/src/General/Index.coffee
+++ b/src/General/Index.coffee
@@ -714,7 +714,7 @@ Index =
         else
           thread = new Thread ID, g.BOARD
           newThreads.push thread
-        lastPost = if threadData.last_replies then threadData.last_replies[threadData.last_replies.length - 1].no else ID
+        lastPost = if threadData.last_replies and threadData.last_replies.length then threadData.last_replies[threadData.last_replies.length - 1].no else ID
         thread.lastPost = lastPost if lastPost > thread.lastPost
         thread.json = threadData
         threads.push thread


### PR DESCRIPTION
Should possibly check to see if the array is empty before allowing unsafe [length-1] since an empty array is boolean True for cooffeescript/js