### PR TITLE
do not clone opened menu

### DIFF
--- a/src/Menu/Menu.coffee
+++ b/src/Menu/Menu.coffee
@@ -21,7 +21,7 @@ Menu =
     if @isClone
       button = $ '.menu-button', @nodes.info
       $.rmClass button, 'active'
-      $.rm $('.dialog', button)
+      $.rm $('.dialog', @nodes.info)
       Menu.makeButton @, button
       return
     $.add @nodes.info, Menu.makeButton @


### PR DESCRIPTION
Currently, when opening a menu of any post, you will, when hovering over / clicking any quotelink, get a nonfunctional menu to go with.
![image](https://user-images.githubusercontent.com/1175752/97502892-56514700-1974-11eb-82d7-047e279745d7.png)
This appears to be an oversight.

With this pr it should look like this instead.
![image](https://user-images.githubusercontent.com/1175752/97503000-87317c00-1974-11eb-8e4a-47d01c60682a.png)
