### PR TITLE
add sauce to gallery

### DIFF
--- a/src/Images/Gallery.coffee
+++ b/src/Images/Gallery.coffee
@@ -51,6 +51,7 @@ Gallery =
       name:    '.gal-name'
       count:   '.count'
       total:   '.total'
+      sauce:   '.gal-sauce'
       thumbs:  '.gal-thumbnails'
       next:    '.gal-image a'
       current: '.gal-image img'
@@ -177,6 +178,15 @@ Gallery =
     nodes.name.href         = thumb.href
     nodes.frame.scrollTop   = 0
     nodes.next.focus()
+
+    # Set sauce links
+    $.rmAll nodes.sauce
+    if Conf['Sauce'] and Sauce.links and (post = g.posts.get(file.dataset.post))
+      sauces = []
+      for link in Sauce.links
+        if (node = Sauce.createSauceLink link, post, post.files[file.dataset.file])
+          sauces.push $.tn(' '), node
+      $.add nodes.sauce, sauces
 
     # Continue slideshow if moving forward, stop otherwise
     if Gallery.slideshow and (newID > oldID or (oldID is Gallery.images.length-1 and newID is 0))

--- a/src/Images/Gallery/Gallery.html
+++ b/src/Images/Gallery/Gallery.html
@@ -5,10 +5,13 @@
     <a href="javascript:;" class="menu-button"><i></i></a>
     <a href="javascript:;" class="gal-close">×</a>
   </span>
-  <a class="gal-name" target="_blank"></a>
-  <span class="gal-count">
-    <span class="count"></span> / <span class="total"></span>
-  </span>
+  <div class="gal-labels">
+    <span class="gal-count">
+      <span class="count"></span> / <span class="total"></span>
+    </span>
+    <a class="gal-name" target="_blank"></a>
+    <span class="gal-sauce"></span>
+  </div>
   <div class="gal-prev"></div>
   <div class="gal-image">
     <a href="javascript:;"><img></a>

--- a/src/Images/Sauce.coffee
+++ b/src/Images/Sauce.coffee
@@ -1,6 +1,7 @@
 Sauce =
   init: ->
     return unless g.VIEW in ['index', 'thread'] and Conf['Sauce']
+    $.addClass doc, 'show-sauce'
 
     links = []
     for link in Conf['sauces'].split '\n'

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -2395,53 +2395,59 @@ a:only-of-type > .remove {
   bottom: 2px;
   vertical-align: baseline;
 }
-.gal-buttons,
-.gal-name,
-.gal-count {
+.gal-labels {
   position: fixed;
-  right: 195px;
-}
-.gal-hide-thumbnails .gal-buttons,
-.gal-hide-thumbnails .gal-count,
-.gal-hide-thumbnails .gal-name {
-  right: 44px;
-}
-.gal-name {
   bottom: 6px;
+  display: -webkit-flex;
+  display: flex;
+  -webkit-flex-direction: column;
+  flex-direction: column;
+  -webkit-align-items: flex-end;
+  align-items: flex-end;
+
+}
+:root:not(.show-sauce) .gal-sauce {
+  display: none;
+}
+.gal-name,
+.gal-count,
+.gal-sauce {
   background: rgba(0,0,0,0.6) !important;
   border-radius: 3px;
   padding: 1px 5px 2px 5px;
+  margin-top: 3px;
+  color: #ffffff !important;
   text-decoration: none !important;
-  color: white !important;
+}
+.gal-sauce a {
+  color: #ffffff !important;
 }
 .gal-name:hover,
-.gal-buttons a:hover {
+.gal-buttons a:hover,
+.gal-sauce a:hover {
   color: rgb(95, 95, 101) !important;
 }
 :root.gal-pdf .gal-buttons a:hover {
   color: rgb(204, 204, 204) !important;
 }
-.gal-count {
-  bottom: 27px;
-  background: rgba(0,0,0,0.6) !important;
-  border-radius: 3px;
-  padding: 1px 5px 2px 5px;
-  color: #ffffff !important;
+.gal-buttons,
+.gal-labels {
+  position: fixed;
+  right: 195px;
 }
-:root:not(.gal-fit-width):not(.gal-pdf) .gal-name {
+.gal-hide-thumbnails .gal-buttons,
+.gal-hide-thumbnails .gal-labels {
+  right: 44px;
+}
+:root:not(.gal-fit-width):not(.gal-pdf) .gal-labels {
   bottom: 23px !important;
 }
-:root:not(.gal-fit-width):not(.gal-pdf) .gal-count {
-  bottom: 44px !important;
-}
 :root.gal-fit-height:not(.gal-pdf):not(.gal-hide-thumbnails) .gal-buttons,
-:root.gal-fit-height:not(.gal-pdf):not(.gal-hide-thumbnails) .gal-name,
-:root.gal-fit-height:not(.gal-pdf):not(.gal-hide-thumbnails) .gal-count {
+:root.gal-fit-height:not(.gal-pdf):not(.gal-hide-thumbnails) .gal-labels {
   right: 178px !important;
 }
 :root.gal-hide-thumbnails.gal-fit-height:not(.gal-pdf) .gal-buttons,
-:root.gal-hide-thumbnails.gal-fit-height:not(.gal-pdf) .gal-name,
-:root.gal-hide-thumbnails.gal-fit-height:not(.gal-pdf) .gal-count {
+:root.gal-hide-thumbnails.gal-fit-height:not(.gal-pdf) .gal-labels {
   right: 28px !important;
 }
 :root.gallery-open.fixed #header-bar:not(.autohide),


### PR DESCRIPTION
add sauce links to gallery when `Sauce` config is enabled
- uses `Sauce.createSauceLink` to make links, so links can only be shown when `Sauce` is enabled (initialized)
- **`.gal-sauce`**, `.gal-name` and `.gal-count` are aligned to the bottom-right with a parent **`.gal-labels`** flexbox; this parent flexbox is positioned the same as how `.gal-name` was positioned before
- when `Sauce` config is disabled, everything should look the same as before

![image](https://user-images.githubusercontent.com/7574985/98449615-c3d64380-20e9-11eb-805c-a193ef322213.png)
