### PR TITLE
Fix Safari instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Ports of Greasemonkey are available for [SeaMonkey](https://sourceforge.net/proj
 Note: This version of 4chan X does not work with Opera 12. If you need Opera 12 support, try [loadletter's fork](https://github.com/loadletter/4chan-x) instead.
 
 ### Safari
-Install [JS Blocker](http://jsblocker.toggleable.com/) or [Tampermonkey](http://tampermonkey.net/?browser=safari), then **[click here to install 4chan X](https://www.4chan-x.net/builds/4chan-X.user.js)**.
+Install the [Userscripts](https://itunes.apple.com/us/app/userscripts/id1463298887) extension. Enable it by pressing `⌘,`, navigating to the extensions pane and checking `Userscripts` chechbox. Now open the Userscripts editor by clicking on the `</>` button in the taskbar. Then click on the `+` button and select the `New Javascript` option. Replace the default text with the contents of the 4chan X **[script](https://www.4chan-x.net/builds/4chan-X.user.js)**. Finally save it by pressing `⌘s`.
 
 ### WebKitGTK+ / QtWebKit / QtWebEngine
 Several minimal browsers have support for userscripts and can run 4chan X. Due to the lack of the cross-site GM_* API, and lack of support for userscripts in iframes, not all features will work. You may experience crashes when repeatedly solving the default image-based captchas. You can avoid this problem by enabling `Use Recaptcha v1` in your settings.

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
 </ul>
 <p>Note: This version of 4chan X does not work with Opera 12. If you need Opera 12 support, try <a href="https://github.com/loadletter/4chan-x">loadletter's fork</a> instead.</p>
 </div><input hidden type="checkbox" id="safari-hide"><div><h3 id="safari"><label for="safari-hide">Safari</label></h3>
-<p>Install <a href="http://jsblocker.toggleable.com/">JS Blocker</a> or <a href="http://tampermonkey.net/?browser=safari">Tampermonkey</a>, then <strong><a href="https://www.4chan-x.net/builds/4chan-X.user.js">click here to install 4chan X</a></strong>.</p>
+<p>Install the <a href="https://itunes.apple.com/us/app/userscripts/id1463298887">Userscripts</a> extension. Enable it by pressing <code>⌘,</code>, navigating to the extensions pane and checking <code>Userscripts</code> chechbox. Now open the Userscripts editor by clicking on the <code>&lt;/&gt;</code> button in the taskbar. Then click on the <code>+</code> button and select the <code>New Javascript</code> option. Replace the default text with the contents of the 4chan X <strong><a href="https://www.4chan-x.net/builds/4chan-X.user.js">script</a></strong>. Finally save it by pressing <code>⌘s</code>.</p>
 </div><input hidden type="checkbox" id="webkitgtk-qtwebkit-qtwebengine-hide"><div><h3 id="webkitgtk-qtwebkit-qtwebengine"><label for="webkitgtk-qtwebkit-qtwebengine-hide">WebKitGTK+ / QtWebKit / QtWebEngine</label></h3>
 <p>Several minimal browsers have support for userscripts and can run 4chan X. Due to the lack of the cross-site GM_* API, and lack of support for userscripts in iframes, not all features will work. You may experience crashes when repeatedly solving the default image-based captchas. You can avoid this problem by enabling <code>Use Recaptcha v1</code> in your settings.</p>
 <ul>


### PR DESCRIPTION
**Problem**
The recommended Safari extensions have been deprecated / paywalled, and as such are no longer viable solutions.

**Solution**
 I figured out a free and functional way to use 4chan X on Safari, which this PR documents.

Ok?

---
```
JS Blocker and TamperMonkey are no longer good options. JS Blocker is
deprecated, see https://jsblocker.toggleable.com, and TamperMonkey
for Safari now costs money.

Therefore I replace these instructions with instructions for
Userscripts. Userscripts has the following advantages to JS Blocker /
TamperMonkey.

- 1. It is free, as in muh freedom and otherwise
- 2. It works with the latest MacOS Safari (14.0.1)
````