### PR TITLE
Settings tabs/buttons element UX

### DIFF
--- a/src/General/Settings.coffee
+++ b/src/General/Settings.coffee
@@ -58,7 +58,7 @@ Settings =
         textContent: section.title
         href: 'javascript:;'
       $.on link, 'click', Settings.openSection.bind section
-      links.push link, $.tn ' | '
+      links.push link
       sectionToOpen = link if section.title is openSection
     links.pop()
     $.add $('.sections-list', dialog), links

--- a/src/General/Settings/Settings.html
+++ b/src/General/Settings/Settings.html
@@ -3,9 +3,9 @@
     <div class="sections-list"></div>
     <p class="imp-exp-result warning"></p>
     <div class="credits">
-        <a class="export">Export</a>&nbsp|&nbsp
-        <a class="import">Import</a>&nbsp|&nbsp
-        <a class="reset">Reset Settings</a>&nbsp|&nbsp
+      <button class="impexres"><a class="export">Export</a></button>
+       <button class="impexres"><a class="import">Import</a></button>
+        <button class="impexres"><a class="reset">Reset Settings</a></button>
         <input type="file" hidden>
       <a href="<%= meta.page %>" target="_blank"><%= meta.name %></a>&nbsp|&nbsp
       <a href="<%= meta.changelog %>" target="_blank">${g.VERSION}</a>&nbsp|&nbsp

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -544,6 +544,9 @@ audio.controls-added {
   padding: 0 2px;
   margin: 0;
 }
+#fourchanx-settings > button.impexre > a {
+  text-decoration:none; color:initial;
+}
 .section-container {
   -webkit-flex: 1;
   flex: 1;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -544,9 +544,6 @@ audio.controls-added {
   padding: 0 2px;
   margin: 0;
 }
-#fourchanx-settings > button.impexre > a {
-  text-decoration:none; color:initial;
-}
 .section-container {
   -webkit-flex: 1;
   flex: 1;
@@ -562,6 +559,9 @@ audio.controls-added {
 .export, .import, .reset {
   cursor: pointer;
   text-decoration: none !important;
+}
+#fourchanx-settings > button.impexres > a, #fourchanx-settings > button.impexres > a:visited {
+  color:initial;
 }
 .tab-selected {
   font-weight: 700;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -560,6 +560,7 @@ audio.controls-added {
   cursor: pointer;
   text-decoration: none !important;
 }
+#fourchanx-settings > button.impexres {margin-right:.5em;}
 #fourchanx-settings > button.impexres > a, #fourchanx-settings > button.impexres > a:visited {
   color:initial;
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -555,17 +555,32 @@ audio.controls-added {
 .sections-list {
   -webkit-flex: 1;
   flex: 1;
+  border-bottom: 1px solid #ccc;
 }
 .export, .import, .reset {
   cursor: pointer;
   text-decoration: none !important;
 }
-#fourchanx-settings > button.impexres {margin-right:.5em;}
+#fourchanx-settings > button.impexres {
+  margin-right:.5em;
+}
 #fourchanx-settings > button.impexres > a, #fourchanx-settings > button.impexres > a:visited {
   color:initial;
 }
+div.sections-list a {
+  display: inline-block;
+  border: 1px solid #ccc;
+  border-top-left-radius: 6px;
+  border-top-right-radius: 6px;
+  border-bottom: none;
+  padding: 0 3px;
+  margin-right: -1px;
+  text-decoration: none !important;
+}
 .tab-selected {
   font-weight: 700;
+  color:#000 !important;
+  background-color:#ccc;
 }
 .section-sauce ul,
 .section-advanced ul {


### PR DESCRIPTION
The Settings dialog has a tabbed interface and 3 buttons but all of these elements are visually links. This patch keeps them as A links but uses CSS to make the tabs obvious and button element wrappers to make the Import/Export/Reset buttons recognizable, leaving the 4chanX/changelog/Issues hyperlinks recognizably links and not something else.
Pipe delimiters have been removed; accessibility solutions should have no difficulty with the semantics of the changes (tabs are already inside a NAV element, BUTTON wrapping A).