### PR TITLE
Add ability to clear whole thread watcher

### DIFF
--- a/src/Monitoring/ThreadWatcher.coffee
+++ b/src/Monitoring/ThreadWatcher.coffee
@@ -126,6 +126,11 @@ ThreadWatcher =
       for a in $$ 'a[title]', ThreadWatcher.list
         $.open a.href
       $.event 'CloseMenu'
+    clear: ->
+      for {siteID, boardID, threadID} in ThreadWatcher.getAll()
+        ThreadWatcher.db.delete {siteID, boardID, threadID}
+      ThreadWatcher.refresh()
+      $.event 'CloseMenu'
     pruneDeads: ->
       return if $.hasClass @, 'disabled'
       for {siteID, boardID, threadID, data} in ThreadWatcher.getAll() when data.isDead
@@ -601,6 +606,13 @@ ThreadWatcher =
       entries.push
         text: 'Open all threads'
         cb: ThreadWatcher.cb.openAll
+        open: ->
+          @el.classList.toggle 'disabled', !ThreadWatcher.list.firstElementChild
+          true
+
+      entries.push
+        text: 'Clear all threads'
+        cb: ThreadWatcher.cb.clear
         open: ->
           @el.classList.toggle 'disabled', !ThreadWatcher.list.firstElementChild
           true

--- a/src/Monitoring/ThreadWatcher.coffee
+++ b/src/Monitoring/ThreadWatcher.coffee
@@ -127,6 +127,7 @@ ThreadWatcher =
         $.open a.href
       $.event 'CloseMenu'
     clear: ->
+      return unless confirm "Delete ALL threads from watcher?"
       for {siteID, boardID, threadID} in ThreadWatcher.getAll()
         ThreadWatcher.db.delete {siteID, boardID, threadID}
       ThreadWatcher.refresh()


### PR DESCRIPTION
Adds the ability to clear the whole thread watcher via a menu item.

I found I needed this after #2925

![image](https://user-images.githubusercontent.com/168193/107110305-0a7c2c80-6804-11eb-8fea-3a41fcd00624.png)

