### PR TITLE
Add randomizeFilename toggle to QuickReply

### DIFF
--- a/src/Posting/QR.coffee
+++ b/src/Posting/QR.coffee
@@ -215,6 +215,21 @@ QR =
     QR.setCustomCooldown enabled
     $.set 'customCooldownEnabled', enabled
 
+  setRandomizedFilename: (enabled) ->
+    Conf['Randomize Filename'] = enabled
+    QR.nodes.randomizedFilename.classList.toggle 'disabled', !enabled
+    if enabled
+      for post in QR.posts when post.file
+        post.randomizeFilename()
+        post.saveFilename()
+        post.showFileData()
+
+  toggleRandomizedFilename: ->
+    enabled = $.hasClass QR.nodes.randomizedFilename, 'disabled'
+    QR.setRandomizedFilename enabled
+    $.set 'Randomize Filename', enabled
+
+
   error: (err, focusOverride) ->
     QR.open()
     if typeof err is 'string'
@@ -528,6 +543,7 @@ QR =
     setNode 'urlButton',      '#url-button'
     setNode 'pasteArea',      '#paste-area'
     setNode 'customCooldown', '#custom-cooldown-button'
+    setNode 'randomizedFilename', '#randomize-filename-button'
     setNode 'dumpButton',     '#dump-button'
     setNode 'status',         '[type=submit]'
     setNode 'flashTag',       '[name=filetag]'
@@ -547,6 +563,10 @@ QR =
       $.get 'customCooldownEnabled', Conf['customCooldownEnabled'], ({customCooldownEnabled}) ->
         QR.setCustomCooldown customCooldownEnabled
         $.sync 'customCooldownEnabled', QR.setCustomCooldown
+
+    $.get 'Randomize Filename', Conf['Randomize Filename'], ({'Randomize Filename': randomizeFilenameEnabled}) ->
+      QR.setRandomizedFilename randomizeFilenameEnabled
+      $.sync 'Randomize Filename', QR.setRandomizedFilename
 
     QR.flagsInput()
 
@@ -568,6 +588,7 @@ QR =
     $.on nodes.fileRM,         'click',     -> QR.selected.rmFile()
     $.on nodes.urlButton,      'click',     -> QR.handleUrl ''
     $.on nodes.customCooldown, 'click',     QR.toggleCustomCooldown
+    $.on nodes.randomizedFilename, 'click', QR.toggleRandomizedFilename
     $.on nodes.dumpButton,     'click',     -> nodes.el.classList.toggle 'dump'
     $.on nodes.fileInput,      'change',    QR.handleFiles
 

--- a/src/Posting/QR.post.coffee
+++ b/src/Posting/QR.post.coffee
@@ -202,10 +202,14 @@ QR.post = class
         error.parentNode.previousElementSibling.click()
     return
 
+
+  randomizeFilename: ->
+    @filename  = "#{Date.now() - Math.floor(Math.random() * 365 * $.DAY)}"
+    @filename += ext[0] if ext = @file.name.match QR.validExtension
+
   setFile: (@file) ->
     if Conf['Randomize Filename'] and g.BOARD.ID isnt 'f'
-      @filename  = "#{Date.now() - Math.floor(Math.random() * 365 * $.DAY)}"
-      @filename += ext[0] if ext = @file.name.match QR.validExtension
+      @randomizeFilename()
     else
       @filename  = @file.name
     @filesize = $.bytesToString @file.size

--- a/src/Posting/QR/QuickReply.html
+++ b/src/Posting/QR/QuickReply.html
@@ -45,6 +45,7 @@
       <a id="url-button" title="Post from URL"><i class="fa fa-link"></i></a>
       <a hidden id="paste-area" title="Select to paste images" class="fa fa-clipboard" tabindex="-1" contentEditable="true"></a>
       <a id="custom-cooldown-button" title="Toggle custom cooldown" class="disabled"><i class="fa fa-clock-o"></i></a>
+      <a id="randomize-filename-button" title="Toglge randomize filename" class="disabled"><i class="fa fa-random"></i></a>
       <a id="dump-button" title="Dump list"><i class="fa fa-plus-square"></i></a>
     </span>
     <input type="submit">


### PR DESCRIPTION
Adds a button to the QuickReply that allows for toggling of randomize filename.

If a file is present when it is clicked, the filename is randomized. This is destructive, the original filename is not restored if toggled off

Fixes #473, #1409, #1574, #1573, #1848, #2200, #2660, #2890