### PR TITLE
Add a button to quick reply to split long posts

### DIFF
--- a/src/Posting/QR.coffee
+++ b/src/Posting/QR.coffee
@@ -352,6 +352,30 @@ QR =
     counter.hidden      = count < QR.max_comment/2
     (if count > QR.max_comment then $.addClass else $.rmClass) counter, 'warning'
 
+    splitPost = QR.nodes.splitPost
+    splitPost.hidden = count < QR.max_comment
+
+  splitPost: ->
+    count = QR.nodes.com.value.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, '_').length
+    text = QR.nodes.com.value
+    return if count < QR.max_comment
+    lastPostLength = 0
+    QR.posts[QR.posts.length - 1].setComment("");
+
+    for line in text.split("\n")
+      currentLength = line.replace(/[\uD800-\uDBFF][\uDC00-\uDFFF]/g, '_').length + 1 # 1 for newline
+      if (currentLength + lastPostLength) > QR.max_comment
+        post = new QR.post()
+        post.setComment(line)
+        lastPostLength = currentLength
+      else
+        currentPost = QR.posts[QR.posts.length - 1]
+        newComment = [currentPost.com, line].filter((el) -> el != null).join("\n")
+        currentPost.setComment(newComment)
+        lastPostLength += currentLength
+
+    QR.nodes.el.classList.add 'dump'
+
   getFile: ->
     $.event 'QRFile', QR.selected?.file
 
@@ -513,6 +537,7 @@ QR =
     setNode 'sub',            '[data-name=sub]'
     setNode 'com',            '[data-name=com]'
     setNode 'charCount',      '#char-count'
+    setNode 'splitPost',      '#split-post'
     setNode 'texPreview',     '#tex-preview'
     setNode 'dumpList',       '#dump-list'
     setNode 'addPost',        '#add-post'
@@ -557,6 +582,7 @@ QR =
     $.on nodes.sjisToggle,     'click',     QR.toggleSJIS
     $.on nodes.texButton,      'mousedown', QR.texPreviewShow
     $.on nodes.texButton,      'mouseup',   QR.texPreviewHide
+    $.on nodes.splitPost,      'click',     QR.splitPost
     $.on nodes.addPost,        'click',     -> new QR.post true
     $.on nodes.drawButton,     'click',     QR.oekaki.draw
     $.on nodes.fileButton,     'click',     QR.openFileInput

--- a/src/Posting/QR/QuickReply.html
+++ b/src/Posting/QR/QuickReply.html
@@ -19,6 +19,7 @@
   <div class="textarea">
     <textarea data-name="com" placeholder="Comment" class="field"></textarea>
     <span id="char-count"></span>
+    <a id="split-post" title="Split into multiple posts" hidden><i class="fa fa-cut"></i></a>
     <div id="tex-preview"></div>
   </div>
   <div id="dump-list-container">

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -2073,6 +2073,13 @@ a:only-of-type > .remove {
 #char-count.warning {
   color: red;
 }
+#split-post {
+  font-size: 8pt;
+  position: absolute;
+  bottom: 2px;
+  left: 2px;
+  cursor: pointer;
+}
 
 /* Menu */
 .menu-button:not(.fa-bars) {


### PR DESCRIPTION
Adds a button which automatically splits long posts into multiple posts
in the dumplist, based on the current maximum post length.

Effort is made to ensure that the new posts are shorter than the max
post length, but there are potentially pathological cases where it will
fail.

![image](https://user-images.githubusercontent.com/168193/107110250-b7a27500-6803-11eb-80c3-912de5fbdcad.png)
![image](https://user-images.githubusercontent.com/168193/107110253-bf621980-6803-11eb-962c-5b04f73bf568.png)
