### PR TITLE
Removed /g/ threads from waruso  - Update archives.json

### DIFF
--- a/src/Archive/archives.json
+++ b/src/Archive/archives.json
@@ -25,7 +25,7 @@
   "http": false,
   "https": true,
   "software": "fuuka",
-  "boards": ["3", "biz", "cgl", "ck", "diy", "fa", "g", "ic", "jp", "lit", "sci", "tg", "vr", "vt"],
+  "boards": ["3", "biz", "cgl", "ck", "diy", "fa", "ic", "jp", "lit", "sci", "tg", "vr", "vt"],
   "files": ["3", "biz", "cgl", "ck", "diy", "fa", "g", "ic", "jp", "lit", "sci", "tg", "vr", "vt"],
   "search": ["biz", "cgl", "ck", "diy", "fa", "g", "ic", "jp", "lit", "sci", "tg", "vr", "vt"]
 }, {


### PR DESCRIPTION
Removed /g/ threads from waruso because its broken as an archive for threads and completely unusable.

See comparison:
waruso:
https://warosu.org/g/thread/81451005

wakarimasen:
https://archive.wakarimasen.moe/g/thread/81451005
