### PR TITLE
Removed dead link to archives.json repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ If you're reporting a bug, the more detail you can give, the better. If I can't 
 
 - 4chan X is mostly written in [CoffeeScript](http://coffeescript.org/). If you're already familiar with Javascript, it doesn't take long to pick up.
 - Edit the sources in the src/ directory (not the compiled scripts in builds/).
-- Fetch needed dependencies with: `npm install`
+- Fetch needed dependencies with: `npm install` 
 - Compile the script with: `make`
 - Install the compiled script (found in the testbuilds/ directory), and test your changes.
 - Make sure you have set your name and email as you want them, as they will be published in your commit message:<br>`git config user.name yourname`<br>`git config user.email youremail`
@@ -41,7 +41,8 @@ If you're reporting a bug, the more detail you can give, the better. If I can't 
   - Push your changes to any online Git repository, and [open an issue](https://gitreports.com/issue/ccd0/4chan-x) with an explanation of your changes and the URL, branch, and commit you want me to pull from.
   - Export your changes via `git bundle` (e.g. `git bundle create file.bundle master..your-branch`), and upload them to a file host. Then [open an issue](https://gitreports.com/issue/ccd0/4chan-x) with an explanation of your changes and the URL of the file.
 
-Archive list updates should go to https://github.com/MayhemYDG/archives.json.
+Pull requests to archive.json should be sent upstream:  https://github.com/4chenz/archives.json   
+4chan X updates from there automatically.
 
 ### More info
 


### PR DESCRIPTION
Removed dead link to: https://github.com/MayhemYDG/archives.json
and replaced with: https://github.com/4chenz/archives.json and updated to text to make it more clear what people should do.

So pull requests like [0d5b5d7](https://github.com/ccd0/4chan-x/pull/3026/commits/0d5b5d7cfe0dc33143fe3a816f00427f05902d3f) can be avoided in the future.
Reference:
[ccd0 comment](https://github.com/ccd0/4chan-x/pull/3026#issuecomment-834708696f)

