### PR TITLE
Fixed Twitch.tv embeds

### DIFF
--- a/src/Linkification/Embedding.coffee
+++ b/src/Linkification/Embedding.coffee
@@ -422,12 +422,15 @@ Embedding =
         text: (_) -> _.title
     ,
       key: 'TwitchTV'
-      regExp: /^\w+:\/\/(?:www\.|secure\.)?twitch\.tv\/(\w[^#\&\?]*)/
+      regExp: /^\w+:\/\/(?:www\.|secure\.|clips\.)?twitch\.tv\/(\w[^#\&\?]*)/
       el: (a) ->
-        m = a.dataset.uid.match /(\w+)(?:\/v\/(\d+))?/
-        url = "//player.twitch.tv/?#{if m[2] then "video=v#{m[2]}" else "channel=#{m[1]}"}&autoplay=false&parent=#{location.hostname}"
-        if (time = a.dataset.href.match /\bt=(\w+)/)
-          url += "&time=#{time[1]}"
+        if a.dataset.href.match(/^\w+:\/\/(www\.|secure\.|clips\.)?twitch\.tv/)[1] is 'clips.'
+          url = "//clips.twitch.tv/embed?clip=#{a.dataset.uid}&parent=#{location.hostname}"
+        else
+          m = a.dataset.uid.match /(\w+)(?:\/(?:v\/)?(\d+))?/
+          url = "//player.twitch.tv/?#{if m[2] then "video=v#{m[2]}" else "channel=#{m[1]}"}&autoplay=false&parent=#{location.hostname}"
+          if (time = a.dataset.href.match /\bt=(\w+)/)
+            url += "&time=#{time[1]}"
         el = $.el 'iframe',
           src: url
         el.setAttribute "allowfullscreen", "true"

--- a/src/Linkification/Embedding.coffee
+++ b/src/Linkification/Embedding.coffee
@@ -424,7 +424,7 @@ Embedding =
       key: 'TwitchTV'
       regExp: /^\w+:\/\/(?:www\.|secure\.|clips\.)?twitch\.tv\/(\w[^#\&\?]*)/
       el: (a) ->
-        if a.dataset.href.match(/^\w+:\/\/(www\.|secure\.|clips\.)?twitch\.tv/)[1] is 'clips.'
+        if a.dataset.href.match(/^\w+:\/\/(?:(clips\.)|\w+\.)?twitch\.tv/)[1]
           url = "//clips.twitch.tv/embed?clip=#{a.dataset.uid}&parent=#{location.hostname}"
         else
           m = a.dataset.uid.match /(\w+)(?:\/(?:v\/)?(\d+))?/

--- a/src/Linkification/Embedding.coffee
+++ b/src/Linkification/Embedding.coffee
@@ -422,10 +422,11 @@ Embedding =
         text: (_) -> _.title
     ,
       key: 'TwitchTV'
-      regExp: /^\w+:\/\/(?:www\.|secure\.|clips\.)?twitch\.tv\/(\w[^#\&\?]*)/
+      regExp: /^\w+:\/\/(?:www\.|secure\.|clips\.|m\.)?twitch\.tv\/(\w[^#\&\?]*)/
       el: (a) ->
-        if a.dataset.href.match(/^\w+:\/\/(?:(clips\.)|\w+\.)?twitch\.tv/)[1]
-          url = "//clips.twitch.tv/embed?clip=#{a.dataset.uid}&parent=#{location.hostname}"
+        m = a.dataset.href.match /^\w+:\/\/(?:(clips\.)|\w+\.)?twitch\.tv\/(clip\/)?(\w[^#\&\?]*)/;
+        if m[1] or m[2]
+          url = "//clips.twitch.tv/embed?clip=#{m[3]}&parent=#{location.hostname}"
         else
           m = a.dataset.uid.match /(\w+)(?:\/(?:v\/)?(\d+))?/
           url = "//player.twitch.tv/?#{if m[2] then "video=v#{m[2]}" else "channel=#{m[1]}"}&autoplay=false&parent=#{location.hostname}"

--- a/src/Linkification/Embedding.coffee
+++ b/src/Linkification/Embedding.coffee
@@ -424,7 +424,7 @@ Embedding =
       key: 'TwitchTV'
       regExp: /^\w+:\/\/(?:www\.|secure\.|clips\.|m\.)?twitch\.tv\/(\w[^#\&\?]*)/
       el: (a) ->
-        m = a.dataset.href.match /^\w+:\/\/(?:(clips\.)|\w+\.)?twitch\.tv\/(clip\/)?(\w[^#\&\?]*)/;
+        m = a.dataset.href.match /^\w+:\/\/(?:(clips\.)|\w+\.)?twitch\.tv\/(?:\w+\/)?(clip\/)?(\w[^#\&\?]*)/;
         if m[1] or m[2]
           url = "//clips.twitch.tv/embed?clip=#{m[3]}&parent=#{location.hostname}"
         else


### PR DESCRIPTION
This is what I'd see for any Twitch embed that wasn't just for the link to someone's channel:

![image](https://user-images.githubusercontent.com/1844566/137897196-02c96580-4ffb-4377-a7c4-88fe49ad592e.png)

VODs were broken, clips didn't seem to have any support at all. Got kinda annoying, so I fixed it. I left the check for what I'm assuming was the old URL scheme for VODs intact in case that's still used somewhere. Maybe really old VODs still use it? IDK, couldn't find any. Found a Twitch VOD link from 2018 with the current scheme, lol. If they do exist, though, they should still work.