### PR TITLE
Fix vocaroo embeds

### DIFF
--- a/src/Linkification/Embedding.coffee
+++ b/src/Linkification/Embedding.coffee
@@ -489,8 +489,7 @@ Embedding =
         el = $.el 'iframe'
         el.width = 300
         el.height = 60
-        el.setAttribute('frameborder', 0);
-        el.allow = "autoplay"
+        el.setAttribute('frameborder', 0)
         el.src = "https://vocaroo.com/embed/#{a.dataset.uid.replace(/^i\//, '')}?autoplay=0"
         el
     ,

--- a/src/Linkification/Embedding.coffee
+++ b/src/Linkification/Embedding.coffee
@@ -486,13 +486,12 @@ Embedding =
       regExp: /^\w+:\/\/(?:(?:www\.|old\.)?vocaroo\.com|voca\.ro)\/((?:i\/)?\w+)/
       style: ''
       el: (a) ->
-        el = $.el 'audio',
-          controls: true
-          preload: 'auto'
-        el.src = if /^i\//.test(a.dataset.uid)
-          "https://old.vocaroo.com/media_command.php?media=#{a.dataset.uid.replace('i/', '')}&command=download_mp3"
-        else
-          "https://media1.vocaroo.com/mp3/#{a.dataset.uid}"
+        el = $.el 'iframe'
+        el.width = 300
+        el.height = 60
+        el.setAttribute('frameborder', 0);
+        el.allow = "autoplay"
+        el.src = "https://vocaroo.com/embed/#{a.dataset.uid.replace(/^i\//, '')}?autoplay=0"
         el
     ,
       key: 'YouTube'


### PR DESCRIPTION
Vocaroo embeds seem to be broken, they return a 403 error now unless you use their own iframe embeds, so I went ahead and implemented the necessary changes to get them to work again. Also, the code to support vocaroo.com/i/[id] format URLs no longer seems to work either, so I removed that as well. Those URLs seem to work with their iframe embeds.