### PR TITLE
Add "Filter-Highlighted" Post Navigation Hotkeys

### DIFF
--- a/src/Filtering/Filter.coffee
+++ b/src/Filtering/Filter.coffee
@@ -400,3 +400,39 @@ Filter =
 
       Filter.addFilter type, res, ->
         Filter.showFilters type
+
+  cb:
+    seek: (type) ->
+      {highlight} = g.SITE.classes
+      $.rmClass highlighted, highlight if (highlighted = $ ".#{highlight}")
+
+      unless Filter.lastRead and doc.contains(Filter.lastRead) and $.hasClass(Filter.lastRead, 'filter-highlight')
+        if not (post = Filter.lastRead = $ '.filter-highlight')
+          new Notice 'warning', 'No posts match your lame filters.', 20
+          return
+        return if Filter.cb.scroll post
+      else
+        post = Filter.lastRead
+
+      str = "#{type}::div[contains(@class,'filter-highlight')]"
+
+      while (post = (result = $.X(str, post)).snapshotItem(if type is 'preceding' then result.snapshotLength - 1 else 0))
+        return if Filter.cb.scroll post
+
+      posts = $$ '.filter-highlight'
+      Filter.cb.scroll posts[if type is 'following' then 0 else posts.length - 1]
+
+    scroll: (root) ->
+      post = Get.postFromRoot root
+      if !post.nodes.post.getBoundingClientRect().height
+        return false
+      else
+        Filter.lastRead = root
+        location.href = Get.url('post', post)
+        Header.scrollTo post.nodes.post
+        if post.isReply
+          sel = "#{g.SITE.selectors.postContainer}#{g.SITE.selectors.highlightable.reply}"
+          node = post.nodes.root
+          node = $ sel, node unless node.matches(sel)
+          $.addClass node, g.SITE.classes.highlight
+        return true

--- a/src/Miscellaneous/Keybinds.coffee
+++ b/src/Miscellaneous/Keybinds.coffee
@@ -200,6 +200,12 @@ Keybinds =
       when Conf['Previous reply']
         return unless threadRoot
         Keybinds.hl -1, threadRoot
+      when Conf['Next filter highlight']
+        return unless threadRoot
+        Filter.cb.seek 'following'
+      when Conf['Previous filter highlight']
+        return unless threadRoot
+        Filter.cb.seek 'preceding'
       when Conf['Deselect reply']
         return unless threadRoot
         Keybinds.hl  0, threadRoot

--- a/src/config/Config.coffee
+++ b/src/config/Config.coffee
@@ -1119,6 +1119,14 @@ Config =
       'Alt+Down'
       'Scroll to the next post that quotes you.'
     ]
+    'Next filter highlight': [
+      'Shift+Alt+Down'
+      'Scroll to the next filter-highlighted post.'
+    ]
+    'Previous filter highlight': [
+      'Shift+Alt+Up'
+      'Scroll to the previous filter-highlighted post.'
+    ]
 
   updater:
     checkbox:


### PR DESCRIPTION
### Why?
I've been using the filter functionality for highlighting of posts relevant to my interests lately, and have wanted a good way to jump between filter-highlighted posts. I really like the way the QuoteYou jumping works with the default Alt+Up/Alt+Down hotkeys, so this was the basis of my expectations for similar filter-based functionality.

### What
The expectation is that, should you have a comment filter like:
```
/heinlein/i;highlight;board:lit
```
That you can then enter a thread on /lit/ discussing people's favorite authors, and press the "next filter-highlight" hotkey to receive either two outcomes:
1. A post mentioning Heinlein is found and the view jumps to it, in a manner similar to if the poster had quoted you and you pressed Alt+Down
2. No posts mentioning Heinlein -- nor the subjects of any other applicable highlight-mode filters -- are found, and (similarly to the QuoteYou system) a message is displayed: "No posts match your lame filters."
![image](https://user-images.githubusercontent.com/33175866/167744530-45aed016-6c44-4950-ba34-278cf9d94d88.png)


### How
- Extends the `Filter.coffee` script to duplicate the seek/scroll and "last highlighted post" memory functionality found within `QuoteYou.coffee`.
  - *This might be a good candidate for consolidating the duplicated functionality into a single "post seeking" method in a common location, but I didn't want to presume to make broader architecture changes without further discussion. If this is more desirable, I can do this work if we work out where to put it.*
- Adds options for setting a hotkey for both Previous & Next filter-highlighted post navigation. By default, Shift+Alt+Up and Shift+Alt+Down, mirroring the QuoteYou default hotkeys.
- Adds hotkey handlers for calling the `Filter.cb.seek` method as appropriate when the hotkey is used.

### Testing
The extent of my testing is that I've loaded the resultant `4chan-x.user.js` v1.14.21.7-based userscript into my Violentmonkey v2.13.0 on Firefox 100.0 and tested that the following conditions are met:
- Hotkeys present and re-configurable in options
- New hotkeys do nothing outside of a thread view on 4chan/yotsuba
- New hotkeys do nothing but display the warning message above when used in a thread with no filter highlights
- New hotkeys jump between filter-highlighted posts when used in a thread with filter highlights, and wrap at the extremes.
  - The OP is included in this, which may or may not be desirable, but I figured this was worth leaving as-is.
- The use of the new Filter seeking system does not impede the use of the QuoteYou functionality.