### PR TITLE
New Option: Avoid Repeated Backlinks when Quoting Text

### DIFF
--- a/src/Posting/QR.coffee
+++ b/src/Posting/QR.coffee
@@ -293,7 +293,8 @@ QR =
     {root} = post.nodes
     postRange = new Range()
     postRange.selectNode root
-    text = if post.board.ID is g.BOARD.ID then ">>#{post}\n" else ">>>/#{post.board}/#{post}\n"
+    quoteBacklink = if post.board.ID is g.BOARD.ID then ">>#{post}\n" else ">>>/#{post.board}/#{post}\n"
+    quoteText = ""
     for i in [0...sel.rangeCount]
       range = sel.getRangeAt i
       # Trim range to be fully inside post
@@ -323,12 +324,20 @@ QR =
       for node in $$ '.embedder', frag
         $.rm node.previousSibling if node.previousSibling?.nodeValue is ' '
         $.rm node
-      text += ">#{frag.textContent.trim()}\n"
+      quoteText = ">#{frag.textContent.trim()}\n"
 
     QR.openPost()
     {com, thread} = QR.nodes
     thread.value = Get.threadFromNode @ unless com.value
 
+    text = quoteBacklink
+    if quoteText != ""
+      alreadyQuoted = com.value.includes quoteBacklink
+      if !Conf['Avoid Duplicated Quotes'] or !alreadyQuoted
+        text = quoteBacklink + quoteText
+      else
+        text = quoteText
+    
     wasOnlyQuotes = QR.selected.isOnlyQuotes()
 
     caretPos = com.selectionStart

--- a/src/config/Config.coffee
+++ b/src/config/Config.coffee
@@ -612,6 +612,10 @@ Config =
         true
         'Add option in header menu to thread conversations.'
       ]
+      'Avoid Duplicated Quotes': [
+        false
+        'Avoid adding a duplicate instances of a given post number when quoting with selected text'
+      ]
 
   imageExpansion:
     'Fit width': [

--- a/src/config/Config.coffee
+++ b/src/config/Config.coffee
@@ -614,7 +614,7 @@ Config =
       ]
       'Avoid Duplicated Quotes': [
         false
-        'Avoid adding a duplicate instances of a given post number when quoting with selected text'
+        'Avoid adding duplicate instances of a given post number when quoting with selected text'
       ]
 
   imageExpansion:


### PR DESCRIPTION
### Why?
When I'm ~~arguing with strangers~~ discussing things on my favorite imageboards, I will sometimes want to use 4chan-X's text quoting feature to make a reply to several of a poster's ~~falsehoods~~ claims. I'll highlight the text to quote and hit the post number to open the QR, and I'll have a backlink and the quoted text.

All good, but if I were to select another passage and hit the quote button again, I get another pesky backlink for each quote:
![image](https://user-images.githubusercontent.com/33175866/167747769-f3a1f62c-0eeb-4da8-a190-1c9d9888154d.png)

It's annoying having to clear out the post numbers each time or manually copy/paste the bits of message. I guess I'm lazy.

### What 
If configured, I'd like 4chan-X to simplify this for me. The expectation is that after I quote a post once, re-selecting text from it and clicking quote again should copy only the text over to my QR box.

This is the expected output, with the new option enabled, and the same quoting procedure as above:
![image](https://user-images.githubusercontent.com/33175866/167748045-ce00256e-c0e6-4238-b888-a961c00d07c8.png)

 ### How
- Modifications to `QR.quote`:
  - Separates the generation of the quote backlink from the quote text.
  - If no quote text was selected, behaves as normal.
  - If quote text was selected, and the new option is enabled, it avoids adding the backlink if the backlink text can already be found in the comment body somewhere. Otherwise, behaves as normal.
- Add an option in the quoting section of the menu to control this behavior. Defaults to "off" (maintains previous behavior)
![image](https://user-images.githubusercontent.com/33175866/167748668-da19e175-b7c5-4943-abee-8fdb5caf219f.png)

### Testing
The extent of my testing is that I've loaded the resultant `4chan-X.user.js` v1.14.21.7-based userscript into my Violentmonkey v2.13.0 on Firefox 100.0 and tested that the following conditions are met:
- The option appears in its default state of disabled
- With the new option disabled, quoting behaves as it always has.
- With the new option enabled, quoting:
  - Behaves as it always has under the following conditions:
    - No highlighted text when quoting a post
    - First time quoting a given post
  - Avoids adding the backlinked post ID otherwise, adding only the selected text as a quote