### PR TITLE
Added an option for thread highlighting to override hiding

### DIFF
--- a/src/Filtering/Filter.coffee
+++ b/src/Filtering/Filter.coffee
@@ -147,6 +147,9 @@ Filter =
             unless hl and filter.hl in hl
               (hl or= []).push filter.hl
             top or= filter.top
+            if filter.hl and Conf['Always Show Highlighted Threads']
+              hide = false
+              hideable = false
             if filter.noti
               noti = true
     if hide
@@ -164,6 +167,7 @@ Filter =
         ThreadHiding.hide @thread, stub
     else
       if hl
+        @thread.isHighlighted = true
         @highlights = hl
         $.addClass @nodes.root, hl...
     if noti and Unread.posts and (@ID > Unread.lastReadPost) and not QuoteYou.isYou(@)

--- a/src/Filtering/ThreadHiding.coffee
+++ b/src/Filtering/ThreadHiding.coffee
@@ -184,7 +184,7 @@ ThreadHiding =
     ThreadHiding.saveHiddenState thread
 
   hide: (thread, makeStub=Conf['Stubs']) ->
-    return if thread.isHidden
+    return if thread.isHidden or (thread.isHighlighted and Conf['Always Show Highlighted Threads'])
     threadRoot = thread.nodes.root
     thread.isHidden = true
     Index.updateHideLabel()

--- a/src/classes/Thread.coffee
+++ b/src/classes/Thread.coffee
@@ -10,6 +10,7 @@ class Thread
     @posts      = new SimpleDict()
     @isDead     = false
     @isHidden   = false
+    @isHighlighted = false
     @isSticky   = false
     @isClosed   = false
     @isArchived = false

--- a/src/config/Config.coffee
+++ b/src/config/Config.coffee
@@ -213,6 +213,10 @@ Config =
         true
         'Add buttons to hide single replies.'
       ]
+      'Always Show Highlighted Threads': [
+        false
+        'Make thread highlighting override hiding.'
+      ]
       'Stubs': [
         true
         'Show stubs of hidden threads / replies.'


### PR DESCRIPTION
Adds a config option to prevent threads from being hidden if they are filter-highlighted.
Should be handy to hide everything except the threads you care about, or to pick out exceptions in your filters.

Fixes #1205