### PR TITLE
replace nbsp with a regular space in quote links

### DIFF
--- a/src/Quotelinks/QuoteCT.coffee
+++ b/src/Quotelinks/QuoteCT.coffee
@@ -5,9 +5,8 @@ QuoteCT =
     if Conf['Comment Expansion']
       ExpandComment.callbacks.push @node
 
-    # \u00A0 is nbsp
     @mark = $.el 'span',
-      textContent: '\u00A0(Cross-thread)'
+      textContent: ' (Cross-thread)'
       className:   'qmark-ct'
     Callbacks.Post.push
       name: 'Mark Cross-thread Quotes'

--- a/src/Quotelinks/QuoteOP.coffee
+++ b/src/Quotelinks/QuoteOP.coffee
@@ -5,9 +5,8 @@ QuoteOP =
     if Conf['Comment Expansion']
       ExpandComment.callbacks.push @node
 
-    # \u00A0 is nbsp
     @mark = $.el 'span',
-      textContent: '\u00A0(OP)'
+      textContent: ' (OP)'
       className:   'qmark-op'
     Callbacks.Post.push
       name: 'Mark OP Quotes'

--- a/src/Quotelinks/QuoteYou.coffee
+++ b/src/Quotelinks/QuoteYou.coffee
@@ -22,9 +22,8 @@ QuoteYou =
     if Conf['Comment Expansion']
       ExpandComment.callbacks.push @node
 
-    # \u00A0 is nbsp
     @mark = $.el 'span',
-      textContent: '\u00A0(You)'
+      textContent: ' (You)'
       className:   'qmark-you'
     Callbacks.Post.push
       name: 'Mark Quotes of You'

--- a/src/classes/Post.coffee
+++ b/src/classes/Post.coffee
@@ -209,9 +209,8 @@ class Post
     file
 
   @deadMark =
-    # \u00A0 is nbsp
     $.el 'span',
-      textContent: '\u00A0(Dead)'
+      textContent: ' (Dead)'
       className:   'qmark-dead'
 
   kill: (file, index=0) ->


### PR DESCRIPTION
this makes quoting (You)s and the like consistent with vanilla 4chan the nbsp is stripped server-side