### PR TITLE
[WIP/Proof] code preview button in QR

### DIFF
--- a/src/Miscellaneous/Fourchan.coffee
+++ b/src/Miscellaneous/Fourchan.coffee
@@ -14,13 +14,16 @@ Fourchan =
           $.addClass pre, 'prettyprinted'
       $.global ->
         window.addEventListener('prettyprint', (e) ->
-          window.dispatchEvent(new CustomEvent('prettyprint:cb', {
-            detail: {
-              ID:   e.detail.ID,
-              i:    e.detail.i,
-              html: window.prettyPrintOne(e.detail.html)
-            }
-          }))
+          if e.target.id is 'code-preview'
+            window.prettyPrintOne(e.target)
+          else
+            window.dispatchEvent(new CustomEvent('prettyprint:cb', {
+              detail: {
+                ID:   e.detail.ID,
+                i:    e.detail.i,
+                html: window.prettyPrintOne(e.detail.html)
+              }
+            }))
         , false)
       Callbacks.Post.push
         name: 'Parse [code] tags'

--- a/src/Posting/QR.coffee
+++ b/src/Posting/QR.coffee
@@ -196,6 +196,15 @@ QR =
 
   texPreviewHide: ->
     $.rmClass QR.nodes.el, 'tex-preview'
+  
+  codePreviewShow: ->
+    return QR.codePreviewHide() if $.hasClass QR.nodes.el, 'code-preview'
+    $.addClass QR.nodes.el, 'code-preview'
+    QR.nodes.codePreview.textContent = QR.nodes.com.value
+    $.event 'prettyprint', null, QR.nodes.codePreview
+  
+  codePreviewHide: ->
+    $.rmClass QR.nodes.el, 'code-preview'
 
   addPost: ->
     wasOpen = (QR.nodes and !QR.nodes.el.hidden)
@@ -509,12 +518,14 @@ QR =
     setNode 'form',           'form'
     setNode 'sjisToggle',     '#sjis-toggle'
     setNode 'texButton',      '#tex-preview-button'
+    setNode 'codeButton',     '#code-preview-button'
     setNode 'name',           '[data-name=name]'
     setNode 'email',          '[data-name=email]'
     setNode 'sub',            '[data-name=sub]'
     setNode 'com',            '[data-name=com]'
     setNode 'charCount',      '#char-count'
     setNode 'texPreview',     '#tex-preview'
+    setNode 'codePreview',    '#code-preview'
     setNode 'dumpList',       '#dump-list'
     setNode 'addPost',        '#add-post'
     setNode 'oekaki',         '.oekaki'
@@ -540,7 +551,9 @@ QR =
     classList.toggle 'has-spoiler',  QR.spoiler
     classList.toggle 'has-sjis',     !!config.sjis_tags
     classList.toggle 'has-math',     !!config.math_tags
+    classList.toggle 'has-code',     !!config.code_tags
     classList.toggle 'sjis-preview', !!config.sjis_tags and Conf['sjisPreview']
+    classList.toggle 'code-preview', !!config.code_tags and Conf['codePreview']
     classList.toggle 'show-new-thread-option', Conf['Show New Thread Option in Threads']
 
     if parseInt(Conf['customCooldown'], 10) > 0
@@ -558,6 +571,8 @@ QR =
     $.on nodes.sjisToggle,     'click',     QR.toggleSJIS
     $.on nodes.texButton,      'mousedown', QR.texPreviewShow
     $.on nodes.texButton,      'mouseup',   QR.texPreviewHide
+    $.on nodes.codeButton,     'mousedown', QR.codePreviewShow
+    $.on nodes.codeButton,     'mouseup',   QR.codePreviewHide
     $.on nodes.addPost,        'click',     -> new QR.post true
     $.on nodes.drawButton,     'click',     QR.oekaki.draw
     $.on nodes.fileButton,     'click',     QR.openFileInput

--- a/src/Posting/QR/QuickReply.html
+++ b/src/Posting/QR/QuickReply.html
@@ -12,6 +12,7 @@
   <div class="persona">
     <button type="button" id="sjis-toggle" title="Toggle Mona font">∀</button>
     <button type="button" id="tex-preview-button" title="Preview TeX">T<sub>E</sub>X</button>
+    <button type="button" id="code-preview-button" title="Preview Code">code</button>
     <input name="name" data-name="name" list="list-name" placeholder="Name" class="field" size="1">
     <input name="email" data-name="email" list="list-email" placeholder="Options" class="field" size="1">
     <input name="sub" data-name="sub" list="list-sub" placeholder="Subject" class="field" size="1">
@@ -20,6 +21,7 @@
     <textarea data-name="com" placeholder="Comment" class="field"></textarea>
     <span id="char-count"></span>
     <div id="tex-preview"></div>
+    <div id="code-preview"></div>
   </div>
   <div id="dump-list-container">
     <div id="dump-list"></div>

--- a/src/config/Config.coffee
+++ b/src/config/Config.coffee
@@ -849,6 +849,7 @@ Config =
       #options:"sage";boards:jp;always
     """
     sjisPreview: false
+    codePreview: false
 
   jsWhitelist: '''
     http://s.4cdn.org

--- a/src/css/spooky.css
+++ b/src/css/spooky.css
@@ -122,7 +122,8 @@
   border-color: rgb(254, 150, 0);
 }
 :root.spooky #qr.sjis-preview #sjis-toggle,
-:root.spooky #qr.tex-preview #tex-preview-button {
+:root.spooky #qr.tex-preview #tex-preview-button,
+:root.spooky #qr.code-preview #code-preview-button {
   background: rgb(26, 27, 29);
 }
 :root.spooky #qr select,

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1668,8 +1668,11 @@ body:not(.board_f) #qr select[name="filetag"],
 #qr.reply-to-thread select[name="filetag"],
 #qr:not(.has-sjis) #sjis-toggle,
 #qr:not(.has-math) #tex-preview-button,
+#qr:not(.has-code) #code-preview-button,
 #qr.tex-preview .textarea > :not(#tex-preview),
-#qr:not(.tex-preview) #tex-preview {
+#qr.code-preview .textarea > :not(#code-preview),
+#qr:not(.tex-preview) #tex-preview,
+#qr:not(.code-preview) #code-preview {
   display: none;
 }
 .persona button {
@@ -1682,7 +1685,7 @@ body:not(.board_f) #qr select[name="filetag"],
   background: linear-gradient(to bottom, #F8F8F8, #DCDCDC) no-repeat;
   color: #000;
 }
-#qr.sjis-preview #sjis-toggle, #qr.tex-preview #tex-preview-button {
+#qr.sjis-preview #sjis-toggle, #qr.tex-preview #tex-preview-button, #qr.code-preview #code-preview-button {
   background: #DCDCDC;
 }
 #sjis-toggle, #qr.sjis-preview textarea.field {
@@ -1695,6 +1698,9 @@ body:not(.board_f) #qr select[name="filetag"],
 }
 #tex-preview {
   white-space: pre-line;
+}
+#code-preview-button {
+  font-family: monospace;
 }
 #qr textarea.field {
   height: 14.8em;

--- a/src/css/tomorrow.css
+++ b/src/css/tomorrow.css
@@ -131,7 +131,8 @@
   border-color: rgb(129, 162, 190);
 }
 :root.tomorrow #qr.sjis-preview #sjis-toggle,
-:root.tomorrow #qr.tex-preview #tex-preview-button {
+:root.tomorrow #qr.tex-preview #tex-preview-button,
+:root.tomorrow #qr.code-preview #code-preview-button {
   background: rgb(26, 27, 29);
 }
 :root.tomorrow #qr select,


### PR DESCRIPTION
Okay, not actually working because I'm missing something, but figure it's a good starting point if someone else wants to pick it up.

The current issues are:
- [ ] trying to get `prettyPrintOne` to run on the `#code-preview` element. When you run it in console, it returns the prettified HTML
- [ ] I think it needs to strip the `[code]` and `[/code]` tags upon preview, as at this point they are included
- [ ] There probably needs to be some way to convert "hey [code]code[/code] this is [code]function() { cool; }[/code]" correctly (in that again, only the text within the code tags is rendered within the existing `prettyprint` and `prettyprinted` classes