### PR TITLE
[WIP/Proof] Filter Labels

### DIFF
--- a/src/Filtering/Filter.coffee
+++ b/src/Filtering/Filter.coffee
@@ -124,6 +124,8 @@ Filter =
     hl   = undefined
     top  = false
     noti = false
+    matcher = undefined
+    fielder = undefined
     if QuoteYou.isYou(post)
       hideable = false
     mask = (if post.isReply then 2 else 1)
@@ -139,6 +141,8 @@ Filter =
             (filter.mask & mask) or
             (if filter.isstring then (filter.regexp isnt value) else !filter.regexp.test(value))
           )
+          matcher = key
+          fielder = filter.regexp
           if filter.hide
             if hideable
               hide = true
@@ -150,21 +154,24 @@ Filter =
             if filter.noti
               noti = true
     if hide
-      {hide, stub}
+      {hide, stub, matcher, fielder}
     else
-      {hl, top, noti}
+      {hl, top, noti, matcher, fielder}
 
   node: ->
     return if @isClone
-    {hide, stub, hl, top, noti} = Filter.test @, (!@isFetchedQuote and (@isReply or g.VIEW is 'index'))
+    {hide, stub, hl, top, noti, matcher, fielder} = Filter.test @, (!@isFetchedQuote and (@isReply or g.VIEW is 'index'))
     if hide
       if @isReply
         PostHiding.hide @, stub
+        @labels.push "Hidden by the #{fielder} in #{matcher}"
       else
         ThreadHiding.hide @thread, stub
+        @labels.push "Hidden by the #{fielder} in #{matcher}"
     else
       if hl
         @highlights = hl
+        @labels.push "Highlighting with #{hl} by the #{fielder} in #{matcher}"
         $.addClass @nodes.root, hl...
     if noti and Unread.posts and (@ID > Unread.lastReadPost) and not QuoteYou.isYou(@)
       Unread.openNotification @, ' triggered a notification filter'

--- a/src/Menu/FilterLabels.coffee
+++ b/src/Menu/FilterLabels.coffee
@@ -1,0 +1,18 @@
+FilterLabels =
+  init: ->
+    return unless g.VIEW in ['index', 'thread'] and Conf['Menu'] and Conf['Filter Labels']
+
+    div = $.el 'div',
+      textContent: 'Labels'
+
+    Menu.menu.addEntry
+      el: div
+      order: 117
+      open: (post) ->
+        {labels} = post.origin or post
+        return false unless labels.length
+        @subEntries.length = 0
+        for label in labels
+          @subEntries.push el: $.el 'div', textContent: label
+        true
+      subEntries: []

--- a/src/classes/Post.coffee
+++ b/src/classes/Post.coffee
@@ -53,6 +53,7 @@ class Post
     @parseQuotes()
     @parseFiles()
 
+    @labels   = []
     @isDead   = false
     @isHidden = false
 

--- a/src/config/Config.coffee
+++ b/src/config/Config.coffee
@@ -364,6 +364,11 @@ Config =
         'Add a download with original filename link to the menu.'
         1
       ]
+      'Filter Labels': [
+        true
+        'Add a menu entry that lists reasons for a post matching a filter.'
+        1
+      ]
 
     'Monitoring':
       'Thread Updater': [

--- a/src/main/Main.coffee
+++ b/src/main/Main.coffee
@@ -664,6 +664,7 @@ Main =
     ['Edit Link',                 QR.oekaki.menu]
     ['Download Link',             DownloadLink]
     ['Archive Link',              ArchiveLink]
+    ['Filter Labels',             FilterLabels]
     ['Quote Inlining',            QuoteInline]
     ['Quote Previewing',          QuotePreview]
     ['Quote Backlinks',           QuoteBacklink]


### PR DESCRIPTION
Another one that is incomplete, but perhaps is a good starting point for others to pick up.

Best to do this on a fresh install and use some filters like `/what/` or `/something/` that don't always hit, within a thread.

Notable issues at this stage include:
 - [ ] I don't actually know what I'm doing, so not sure if I'm referencing things correctly
 - [ ] Within the Label menu, entries are not given the `.entry` class like other submenu items
 - [ ] Sometimes a random `true` is added to the Label list, not sure where or how
 - [ ] Threads probably don't work
 - [ ] Unhiding a post doesn't update the label list correctly
 - [ ] As mentioned in #3359, posts currently can't be marked hidden AND highlighted
 - [ ] Haven't tested multiple highlights
 - [ ] Perhaps clicking on the matching filter label should take you to that line in the filter list?

Perhaps not in the scope of this PR, but I suppose there should be a setting that shows the labels in Stubs, some form of overriding, and being able to detect if a filter is hiding all posts (warning on initial incase it was an error, allow it to be dismissed if someone really never wanted to see posts that use the letter "a").