### PR TITLE
Added Gallery option to display image dimensions

### DIFF
--- a/src/Images/Gallery.coffee
+++ b/src/Images/Gallery.coffee
@@ -46,15 +46,16 @@ Gallery =
     $.extend dialog, `<%= readHTML('Gallery.html') %>`
 
     nodes[key] = $ value, dialog for key, value of {
-      buttons: '.gal-buttons'
-      frame:   '.gal-image'
-      name:    '.gal-name'
-      count:   '.count'
-      total:   '.total'
-      sauce:   '.gal-sauce'
-      thumbs:  '.gal-thumbnails'
-      next:    '.gal-image a'
-      current: '.gal-image img'
+      buttons:    '.gal-buttons'
+      frame:      '.gal-image'
+      name:       '.gal-name'
+      dimensions: '.gal-dimensions'
+      count:      '.count'
+      total:      '.total'
+      sauce:      '.gal-sauce'
+      thumbs:     '.gal-thumbnails'
+      next:       '.gal-image a'
+      current:    '.gal-image img'
     }
 
     menuButton = $ '.menu-button', dialog
@@ -178,6 +179,10 @@ Gallery =
     nodes.name.href         = thumb.href
     nodes.frame.scrollTop   = 0
     nodes.next.focus()
+
+    if Conf['Image Resolution'] and (post = g.posts.get(file.dataset.post)) and post.file.dimensions
+      [w, h] = post.file.dimensions.split('x')
+      nodes.dimensions.innerText = "#{w} x #{h} px"
 
     # Set sauce links
     $.rmAll nodes.sauce

--- a/src/Images/Gallery/Gallery.html
+++ b/src/Images/Gallery/Gallery.html
@@ -10,6 +10,7 @@
       <span class="count"></span> / <span class="total"></span>
     </span>
     <a class="gal-name" target="_blank"></a>
+    <span class="gal-dimensions"></span>
     <span class="gal-sauce"></span>
   </div>
   <div class="gal-prev"></div>

--- a/src/config/Config.coffee
+++ b/src/config/Config.coffee
@@ -245,6 +245,11 @@ Config =
         'Show PDF files in gallery.'
         1
       ]
+      'Image Resolution': [
+        false
+        'Shows the dimensions of the image you\'re viewing in the gallery.'
+        1
+      ]
       'Sauce': [
         true
         'Add sauce links to images.'

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -2418,6 +2418,7 @@ a:only-of-type > .remove {
   display: none;
 }
 .gal-name,
+.gal-dimensions,
 .gal-count,
 .gal-sauce {
   background: rgba(0,0,0,0.6) !important;
@@ -2434,6 +2435,9 @@ a:only-of-type > .remove {
 .gal-buttons a:hover,
 .gal-sauce a:hover {
   color: rgb(95, 95, 101) !important;
+}
+.gal-dimensions:empty {
+  display: none;
 }
 :root.gal-pdf .gal-buttons a:hover {
   color: rgb(204, 204, 204) !important;


### PR DESCRIPTION
Adds an additional info panel (disabled by default) that shows the dimensions of the image you're viewing in gallery mode. This is useful on boards like /wg/ where one would want to quickly see the resolution of the image they're looking at.

The dimensions display under the filename and above the sauce links:

![image](https://github.com/ccd0/4chan-x/assets/6566104/e96ff1ad-1170-4284-b73e-e8fb3502290b)

Additionally, when the option is disabled, the dimensions span is set to `display: none` so it doesn't add any extra spacing/padding and make the UI look weird.

This closes #198 (from 2014!)