### PR TITLE
Fix for cloudflare verification issue

### DIFF
--- a/src/config/Config.coffee
+++ b/src/config/Config.coffee
@@ -859,11 +859,13 @@ Config =
     http://cdn.mathjax.org
     https://cdn.mathjax.org
     https://cdnjs.cloudflare.com
+    https://challenges.cloudflare.com
     https://hcaptcha.com
     https://*.hcaptcha.com
     'self'
     'unsafe-inline'
     'unsafe-eval'
+    object-src 'self' blob:
   '''
 
   captchaLanguage: ''


### PR DESCRIPTION
Fixes #3407 

The issue was that 4chanx's JS Whitelist functionality blocks any type of "blob:" url, one of which is used briefly in Cloudflare's code.  Once that was handled, challenges.cloudflare.com was found to be blocked as well.  By adding blobs and the challenges domain to the whitelist, the cloudflare verification check proceeds without problems.

The code compiles and was tested to work by enabling the plugin, clearing the cloudflare cookies on 4chan.org, then reloading the page to see the cloudflare verification page appear and redirect successfully.  Testing was done in Chrome 118.0.5993.89 on Win 10.