### PR TITLE
Fix settings import from 4chan XT by not assuming every "2." is from loadletter/4chan-x

### DIFF
--- a/src/General/Settings.coffee
+++ b/src/General/Settings.coffee
@@ -556,7 +556,7 @@ Settings =
     changes
 
   loadSettings: (data, cb) ->
-    if data.version.split('.')[0] is '2' # https://github.com/loadletter/4chan-x
+    if data.version.split('.')[0] is '2' and "Disable 4chan's extension" of data.Conf # https://github.com/loadletter/4chan-x
       data = Settings.convertFrom.loadletter data
     else if data.version isnt g.VERSION
       Settings.upgrade data.Conf, data.version


### PR DESCRIPTION
I bumped the major version of my [4chan XT](https://github.com/TuxedoTako/4chan-xt) fork to 2, but that broke the settings import https://github.com/TuxedoTako/4chan-xt/issues/16, because that assumes version 2 is from [loadletter/4chan-x](https://github.com/loadletter/4chan-x). This fixed that by also checking a setting name that loadletter/4chan-x changed but 4chan XT didn't.