### PR TITLE
Fallback when XPCNativeWrapper is unavailable

### DIFF
--- a/src/platform/$.coffee
+++ b/src/platform/$.coffee
@@ -67,9 +67,9 @@ $.getOwn = (obj, key) ->
   if Object::hasOwnProperty.call(obj, key) then obj[key] else undefined
 
 $.ajax = do ->
-  if window.wrappedJSObject and not XMLHttpRequest.wrappedJSObject
-    pageXHR = XPCNativeWrapper window.wrappedJSObject.XMLHttpRequest
-  else
+  try
+    pageXHR = if window.wrappedJSObject and not XMLHttpRequest.wrappedJSObject then XPCNativeWrapper window.wrappedJSObject.XMLHttpRequest else XMLHttpRequest
+  catch
     pageXHR = XMLHttpRequest
 
   (url, options={}) ->


### PR DESCRIPTION
Fixes an issue preventing the extension from being used on [Orion](https://kagi.com/orion/).

<img width="527" alt="image" src="https://github.com/ccd0/4chan-x/assets/86283021/fd6af691-b191-4924-bef4-e835b38e6a83">
