### PR TITLE
Add #t-task to selector for verification message check to accommodate the December 16, 2025, CAPTCHA update

### DIFF
--- a/src/Posting/Captcha.t.coffee
+++ b/src/Posting/Captcha.t.coffee
@@ -60,7 +60,7 @@ Captcha.t =
     if @nodes.container
       for key in ['t-response', 't-challenge']
         response[key] = $("[name='#{key}']", @nodes.container).value
-    if !response['t-response'] and !((el = $('#t-msg')) and /Verification not required/i.test(el.textContent))
+    if !response['t-response'] and !((el = $('#t-msg, #t-task')) and /Verification not required/i.test(el.textContent))
       response = null
     response
 


### PR DESCRIPTION
The CAPTCHA's been updated and 4chan X doesn't realize when verification isn't required.
It's because the id of the "verification not required" element has changed from `#t-msg` to `#t-task`.
This commit changes the selector from `#t-msg` to `#t-msg, #t-task`.