### PR TITLE
fix: update Chrome Web Store URLs to new domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ Install [Violentmonkey](https://addons.mozilla.org/en-US/firefox/addon/violentmo
 Ports of Greasemonkey are available for [SeaMonkey](https://sourceforge.net/projects/gmport/) and [Pale Moon](https://github.com/janekptacijarabaci/greasemonkey/releases/latest).
 
 ### Chromium
-**Userscript**: Install [Violentmonkey](https://chrome.google.com/webstore/detail/violent-monkey/jinjaccalgkegednnccohejagnlnfdag) or [Tampermonkey](https://tampermonkey.net/), then **[click here to install 4chan X](https://www.4chan-x.net/builds/4chan-X.user.js)**.
+**Userscript**: Install [Violentmonkey](https://chromewebstore.google.com/detail/violent-monkey/jinjaccalgkegednnccohejagnlnfdag) or [Tampermonkey](https://tampermonkey.net/), then **[click here to install 4chan X](https://www.4chan-x.net/builds/4chan-X.user.js)**.
 
 **Chrome extension**: 4chan X is also available as a standalone Chrome extension. The Chrome extension has the additional feature of being able to sync your settings and data with other devices via Chrome Sync. But there is an issue when the script updates: Whenever the Chrome extension is updated, until you hard refresh (F5) the tab, 4chan X is unable to save any data (such as posts marked as yours and settings changes). The userscript version above does not have this problem when 4chan X updates, only when Violentmonkey / Tampermonkey is updated. To install as a Chrome extension:
 
-- **Chromium**, **Vivaldi**: **[Download 4chan X](https://www.4chan-x.net/builds/4chan-X.crx)**, then open `chrome://extensions` and drag the downloaded file onto the page. Alternatively, you can install 4chan X from the **[Chrome store](https://chrome.google.com/webstore/detail/ohnjgmpcibpbafdlkimncjhflgedgpam)**.
+- **Chromium**, **Vivaldi**: **[Download 4chan X](https://www.4chan-x.net/builds/4chan-X.crx)**, then open `chrome://extensions` and drag the downloaded file onto the page. Alternatively, you can install 4chan X from the **[Chrome store](https://chromewebstore.google.com/detail/ohnjgmpcibpbafdlkimncjhflgedgpam)**.
 - **Opera**: **[Click to install 4chan X](https://www.4chan-x.net/builds/4chan-X.crx)**, then follow the prompts to activate it in your extension manager.
-- **Chrome**: Install 4chan X from the **[Chrome store](https://chrome.google.com/webstore/detail/ohnjgmpcibpbafdlkimncjhflgedgpam)**.
+- **Chrome**: Install 4chan X from the **[Chrome store](https://chromewebstore.google.com/detail/ohnjgmpcibpbafdlkimncjhflgedgpam)**.
 
 Note: This version of 4chan X does not work with Opera 12. If you need Opera 12 support, try [loadletter's fork](https://github.com/loadletter/4chan-x) instead.
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <title>4chan X</title>
 <link rel="stylesheet" href="web.css">
 <link rel="icon" href="img/icon.gif">
-<link rel="chrome-webstore-item" href="https://chrome.google.com/webstore/detail/ohnjgmpcibpbafdlkimncjhflgedgpam">
+<link rel="chrome-webstore-item" href="https://chromewebstore.google.com/detail/ohnjgmpcibpbafdlkimncjhflgedgpam">
 </head><body>
 <div id="header">
 <h1 id="4chan-x">4chan X</h1>
@@ -31,12 +31,12 @@
 <p>Install <a href="https://addons.mozilla.org/en-US/firefox/addon/violentmonkey/">Violentmonkey</a>, <a href="https://addons.mozilla.org/en-US/firefox/addon/tampermonkey/">Tampermonkey</a>, or <a href="https://addons.mozilla.org/en-US/firefox/addon/greasemonkey/">Greasemonkey</a> (issues since v4: <a href="https://github.com/greasemonkey/greasemonkey/issues/2526">#2526</a>, <a href="https://github.com/greasemonkey/greasemonkey/issues/2574">#2576</a>), then <strong><a href="https://www.4chan-x.net/builds/4chan-X.user.js">click here to install 4chan X</a></strong>.</p>
 <p>Ports of Greasemonkey are available for <a href="https://sourceforge.net/projects/gmport/">SeaMonkey</a> and <a href="https://github.com/janekptacijarabaci/greasemonkey/releases/latest">Pale Moon</a>.</p>
 </div><input hidden type="checkbox" id="chromium-hide"><div><h3 id="chromium"><label for="chromium-hide">Chromium</label></h3>
-<p><strong>Userscript</strong>: Install <a href="https://chrome.google.com/webstore/detail/violent-monkey/jinjaccalgkegednnccohejagnlnfdag">Violentmonkey</a> or <a href="https://tampermonkey.net/">Tampermonkey</a>, then <strong><a href="https://www.4chan-x.net/builds/4chan-X.user.js">click here to install 4chan X</a></strong>.</p>
+<p><strong>Userscript</strong>: Install <a href="https://chromewebstore.google.com/detail/violent-monkey/jinjaccalgkegednnccohejagnlnfdag">Violentmonkey</a> or <a href="https://tampermonkey.net/">Tampermonkey</a>, then <strong><a href="https://www.4chan-x.net/builds/4chan-X.user.js">click here to install 4chan X</a></strong>.</p>
 <p><strong>Chrome extension</strong>: 4chan X is also available as a standalone Chrome extension. The Chrome extension has the additional feature of being able to sync your settings and data with other devices via Chrome Sync. But there is an issue when the script updates: Whenever the Chrome extension is updated, until you hard refresh (F5) the tab, 4chan X is unable to save any data (such as posts marked as yours and settings changes). The userscript version above does not have this problem when 4chan X updates, only when Violentmonkey / Tampermonkey is updated. To install as a Chrome extension:</p>
 <ul>
-<li><strong>Chromium</strong>, <strong>Vivaldi</strong>: <strong><a href="https://www.4chan-x.net/builds/4chan-X.crx">Download 4chan X</a></strong>, then open <code>chrome://extensions</code> and drag the downloaded file onto the page. Alternatively, you can install 4chan X from the <strong><a href="https://chrome.google.com/webstore/detail/ohnjgmpcibpbafdlkimncjhflgedgpam">Chrome store</a></strong>.</li>
+<li><strong>Chromium</strong>, <strong>Vivaldi</strong>: <strong><a href="https://www.4chan-x.net/builds/4chan-X.crx">Download 4chan X</a></strong>, then open <code>chrome://extensions</code> and drag the downloaded file onto the page. Alternatively, you can install 4chan X from the <strong><a href="https://chromewebstore.google.com/detail/ohnjgmpcibpbafdlkimncjhflgedgpam">Chrome store</a></strong>.</li>
 <li><strong>Opera</strong>: <strong><a href="https://www.4chan-x.net/builds/4chan-X.crx">Click to install 4chan X</a></strong>, then follow the prompts to activate it in your extension manager.</li>
-<li><strong>Chrome</strong>: Install 4chan X from the <strong><a href="https://chrome.google.com/webstore/detail/ohnjgmpcibpbafdlkimncjhflgedgpam">Chrome store</a></strong>.</li>
+<li><strong>Chrome</strong>: Install 4chan X from the <strong><a href="https://chromewebstore.google.com/detail/ohnjgmpcibpbafdlkimncjhflgedgpam">Chrome store</a></strong>.</li>
 </ul>
 <p>Note: This version of 4chan X does not work with Opera 12. If you need Opera 12 support, try <a href="https://github.com/loadletter/4chan-x">loadletter's fork</a> instead.</p>
 </div><input hidden type="checkbox" id="safari-hide"><div><h3 id="safari"><label for="safari-hide">Safari</label></h3>

--- a/template.jst
+++ b/template.jst
@@ -4,7 +4,7 @@
 <title>4chan X</title>
 <link rel="stylesheet" href="web.css">
 <link rel="icon" href="img/icon.gif">
-<link rel="chrome-webstore-item" href="https://chrome.google.com/webstore/detail/ohnjgmpcibpbafdlkimncjhflgedgpam">
+<link rel="chrome-webstore-item" href="https://chromewebstore.google.com/detail/ohnjgmpcibpbafdlkimncjhflgedgpam">
 </head><body>
 <div id="header">
 <h1 id="4chan-x">4chan X</h1>

--- a/tools/webstore.js
+++ b/tools/webstore.js
@@ -15,7 +15,7 @@ import('chrome-webstore-upload').then(chromeWebstoreUpload => {
     refreshToken: refresh.refresh_token
   });
 
-  request(`https://chrome.google.com/webstore/detail/${pkg.meta.chromeStoreID}`, function (error, response, body) {
+  request(`https://chromewebstore.google.com/detail/${pkg.meta.chromeStoreID}`, function (error, response, body) {
 
     if (body && body.indexOf(`<meta itemprop="version" content="${v.version}"/>`) > 0 && process.argv[2] !== 'force') {
       console.log(`Version ${v.version} already uploaded.`);


### PR DESCRIPTION
Updates old Chrome Web Store URLs (chrome.google.com/webstore) to new format (chromewebstore.google.com) for improved compatibility.

Files changed:
- README.md (3 URLs)
- index.html (4 URLs)
- template.jst (1 URL)
- tools/webstore.js (1 URL)

Total: 9 URLs updated.