### PR TITLE
Fix makeMenu() touch event propagation

### DIFF
--- a/src/General/UI.coffee
+++ b/src/General/UI.coffee
@@ -32,7 +32,7 @@ class Menu
       id:        'menu'
       tabIndex:  0
     menu.dataset.type = @type
-    $.on menu, 'click', (e) -> e.stopPropagation()
+    $.on menu, 'click touchstart mousedown', (e) -> e.stopPropagation()
     $.on menu, 'keydown', @keybinds
     menu
 


### PR DESCRIPTION
## Bug

On touch devices, dropdown menus created via `Menu` (post menus, catalog
menus, filter menu, thread watcher menu, etc.) have two related problems
when opened from inside a draggable dialog (one with a `.move` header,
like the Thread Watcher):

1. Taps on menu items are unreliable. They can silently fail, or register
   against whatever element is underneath the menu instead.
2. Dragging on an open menu drags the whole parent dialog around the
   viewport, as if the menu itself were the drag handle. The menu stays
   fixed in place while the dialog moves underneath it.

## Root cause

`dialog()` protects its `.move` header's buttons from starting a drag by
looping over `move.children` once, at construction time:

```coffee
for child in move.children
  continue unless child.tagName
  $.on child, 'touchstart mousedown', (e) ->
    e.stopPropagation()
```

`Menu.prototype.open` inserts the menu later, as a sibling of its toggle
button. If that button lives inside `.move`, the menu becomes a child of
`.move` too, but it's created after the loop above already ran, so it
never gets the guard.

`Menu.makeMenu()` also only stops propagation on `click`, not on
`touchstart`/`mousedown`:

```coffee
$.on menu, 'click', (e) -> e.stopPropagation()
```

So a `touchstart` on the menu bubbles up to `.move`'s `dragstart`
listener, which calls `preventDefault()` and starts tracking a drag,
hijacking the gesture before it resolves into a tap on the entry
underneath.

## Fix

One line, extending the existing guard to match `dialog()`'s own pattern:

```diff
-    $.on menu, 'click', (e) -> e.stopPropagation()
+    $.on menu, 'click touchstart mousedown', (e) -> e.stopPropagation()
```

`stopPropagation` only blocks the event from reaching `.move`'s drag
handler further up the tree. It doesn't affect the menu's own
entry-selection logic, which lives on descendants and fires first.

`Menu` is shared by every dropdown in the extension, so this fixes the
issue for all of them, not just the watcher.

## Testing

Built with `make`, tested the resulting userscript via Violentmonkey on
Firefox Mobile (GrapheneOS). Confirmed both symptoms are resolved, no
regressions to normal menu behavior.